### PR TITLE
Block place and Block break events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 def ENV = System.getenv()
 
 class Globals {
-	static def baseVersion = "0.3.2"
+	static def baseVersion = "0.3.3"
 	static def mcVersion = "1.8.9"
 	static def yarnVersion = "+build.202007100557"
 }

--- a/fabric-events-interaction-v0/build.gradle
+++ b/fabric-events-interaction-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-events-interaction-v0"
-version = getSubprojectVersion(project, "0.4.0")
+version = getSubprojectVersion(project, "0.4.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/BreakBlockCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/BreakBlockCallback.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.event.player;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.fabricmc.fabric.impl.base.util.ActionResult;
+
+/**
+ * Callback for breaking a block.
+ *
+ * <p>Upon return:
+ * <ul><li>SUCCESS cancels further processing and breaks the block.
+ * <li>PASS falls back to further processing.
+ * <li>FAIL cancels further processing and does not break the block.</ul>
+ */
+public interface BreakBlockCallback {
+	Event<BreakBlockCallback> EVENT = EventFactory.createArrayBacked(BreakBlockCallback.class,
+			(listeners) -> (player, world, pos) -> {
+				for (BreakBlockCallback event : listeners) {
+					ActionResult result = event.blockBreak(player, world, pos);
+
+					if (result != ActionResult.PASS) {
+						return result;
+					}
+				}
+
+				return ActionResult.PASS;
+			}
+	);
+
+	ActionResult blockBreak(PlayerEntity player, World world, BlockPos pos);
+}

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlaceBlockCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlaceBlockCallback.java
@@ -48,5 +48,5 @@ public interface PlaceBlockCallback {
 			}
 	);
 
-	ActionResult blockPlaced(PlayerEntity player, World world, BlockPos pos, Direction dir, float hitX, float  hitY, float hitZ);
+	ActionResult blockPlaced(PlayerEntity player, World world, BlockPos pos, Direction dir, float hitX, float hitY, float hitZ);
 }

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlaceBlockCallback.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/api/event/player/PlaceBlockCallback.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.event.player;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.fabricmc.fabric.impl.base.util.ActionResult;
+
+/**
+ * Callback for placing a block.
+ *
+ * <p>Upon return:
+ * <ul><li>SUCCESS cancels further processing and places the block.
+ * <li>PASS falls back to further processing.
+ * <li>FAIL cancels further processing and does not place the block.</ul>
+ */
+public interface PlaceBlockCallback {
+	Event<PlaceBlockCallback> EVENT = EventFactory.createArrayBacked(PlaceBlockCallback.class,
+			(listeners) -> (player, world, pos, dir, hitX, hitY, hitZ) -> {
+				for (PlaceBlockCallback event : listeners) {
+					ActionResult result = event.blockPlaced(player, world, pos, dir, hitX, hitY, hitZ);
+
+					if (result != ActionResult.PASS) {
+						return result;
+					}
+				}
+
+				return ActionResult.PASS;
+			}
+	);
+
+	ActionResult blockPlaced(PlayerEntity player, World world, BlockPos pos, Direction dir, float hitX, float  hitY, float hitZ);
+}

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinItemStack.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinItemStack.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.event.interaction;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -17,8 +33,8 @@ import net.fabricmc.fabric.impl.base.util.ActionResult;
 @Mixin(ItemStack.class)
 public class MixinItemStack {
 	@Inject(at = @At("HEAD"), method = "method_8347", cancellable = true)
-	public void blockPlaced(PlayerEntity playerEntity, World world, BlockPos blockPos, Direction direction, float hitX, float hitY, float hitZ, CallbackInfoReturnable<Boolean> info) {
-		ActionResult result = PlaceBlockCallback.EVENT.invoker().blockPlaced(playerEntity, world, blockPos, direction, hitX , hitY, hitZ);
+	public void blockPlaced (PlayerEntity playerEntity, World world, BlockPos blockPos, Direction direction, float hitX, float hitY, float hitZ, CallbackInfoReturnable<Boolean> info) {
+		ActionResult result = PlaceBlockCallback.EVENT.invoker().blockPlaced(playerEntity, world, blockPos, direction, hitX, hitY, hitZ);
 
 		if (result == ActionResult.FAIL) {
 			info.setReturnValue(false);

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinItemStack.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinItemStack.java
@@ -1,0 +1,27 @@
+package net.fabricmc.fabric.mixin.event.interaction;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+
+import net.fabricmc.fabric.api.event.player.PlaceBlockCallback;
+import net.fabricmc.fabric.impl.base.util.ActionResult;
+
+@Mixin(ItemStack.class)
+public class MixinItemStack {
+	@Inject(at = @At("HEAD"), method = "method_8347", cancellable = true)
+	public void blockPlaced(PlayerEntity playerEntity, World world, BlockPos blockPos, Direction direction, float hitX, float hitY, float hitZ, CallbackInfoReturnable<Boolean> info) {
+		ActionResult result = PlaceBlockCallback.EVENT.invoker().blockPlaced(playerEntity, world, blockPos, direction, hitX , hitY, hitZ);
+
+		if (result == ActionResult.FAIL) {
+			info.setReturnValue(false);
+		}
+	}
+}

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinServerPlayerInteractionManager.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinServerPlayerInteractionManager.java
@@ -81,7 +81,7 @@ public class MixinServerPlayerInteractionManager {
 	}
 
 	@Inject(at = @At("HEAD"), method = "method_6096", cancellable = true)
-	public void breakBlocK(BlockPos blockPos, CallbackInfoReturnable<Boolean> info) {
+	public void breakBlock(BlockPos blockPos, CallbackInfoReturnable<Boolean> info) {
 		ActionResult result = BreakBlockCallback.EVENT.invoker().blockBreak(this.player, this.world, blockPos);
 
 		if (result == ActionResult.FAIL) {

--- a/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinServerPlayerInteractionManager.java
+++ b/fabric-events-interaction-v0/src/main/java/net/fabricmc/fabric/mixin/event/interaction/MixinServerPlayerInteractionManager.java
@@ -35,6 +35,7 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
 import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
+import net.fabricmc.fabric.api.event.player.BreakBlockCallback;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.fabricmc.fabric.api.event.player.UseItemCallback;
 import net.fabricmc.fabric.impl.base.util.ActionResult;
@@ -76,6 +77,15 @@ public class MixinServerPlayerInteractionManager {
 		if (result.getResult() != ActionResult.PASS) {
 			info.setReturnValue(result.getResult());
 			info.cancel();
+		}
+	}
+
+	@Inject(at = @At("HEAD"), method = "method_6096", cancellable = true)
+	public void breakBlocK(BlockPos blockPos, CallbackInfoReturnable<Boolean> info) {
+		ActionResult result = BreakBlockCallback.EVENT.invoker().blockBreak(this.player, this.world, blockPos);
+
+		if (result == ActionResult.FAIL) {
+			info.setReturnValue(false);
 		}
 	}
 }

--- a/fabric-events-interaction-v0/src/main/resources/fabric-events-interaction-v0.mixins.json
+++ b/fabric-events-interaction-v0/src/main/resources/fabric-events-interaction-v0.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.fabricmc.fabric.mixin.event.interaction",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "MixinItemStack",
     "MixinServerPlayerEntity",
     "MixinServerPlayerInteractionManager",
     "MixinServerPlayNetworkHandler"


### PR DESCRIPTION
Two new callbacks that allow running code when a block is broken or placed. 
Return values (for both):-
`ActionResult.PASS` - Falls back to further processing. 
`ActionResult.SUCCESS` - Cancels further processing and performs the action.
`ActionResult.FAIL` - Cancels further processing and does not perform the action. 