### PR TITLE
custom payload events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 def ENV = System.getenv()
 
 class Globals {
-	static def baseVersion = "0.4.1"
+	static def baseVersion = "0.4.2"
 	static def mcVersion = "1.8.9"
 	static def yarnVersion = "+build.202007100557"
 }

--- a/fabric-lifecycle-events-v1/build.gradle
+++ b/fabric-lifecycle-events-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-lifecycle-events-v1"
-version = getSubprojectVersion(project, "1.0.0")
+version = getSubprojectVersion(project, "1.0.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-lifecycle-events-v1/build.gradle
+++ b/fabric-lifecycle-events-v1/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-lifecycle-events-v1"
-version = getSubprojectVersion(project, "1.0.1")
+version = getSubprojectVersion(project, "1.1.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientNetworkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientNetworkEvents.java
@@ -36,6 +36,7 @@ public class ClientNetworkEvents {
 		}
 	});
 
+	@FunctionalInterface
 	public interface CustomPayload {
 		void onCustomPayload(String channel, PacketByteBuf data);
 	}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientNetworkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/client/event/lifecycle/v1/ClientNetworkEvents.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.client.event.lifecycle.v1;
+
+import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
+import net.minecraft.util.PacketByteBuf;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+@Environment(EnvType.CLIENT)
+public class ClientNetworkEvents {
+	/**
+	 * Called when the client receives a {@link CustomPayloadS2CPacket}.
+	 * Useful when making server plugin companion mods.
+	 */
+	public static final Event<CustomPayload> CUSTOM_PAYLOAD = EventFactory.createArrayBacked(CustomPayload.class, listeners -> (channel, data) -> {
+		for (CustomPayload callback : listeners) {
+			callback.onCustomPayload(channel, data);
+		}
+	});
+
+	public interface CustomPayload {
+		void onCustomPayload(String channel, PacketByteBuf data);
+	}
+}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerNetworkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerNetworkEvents.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.fabricmc.fabric.api.event.lifecycle.v1;
+
+import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
+import net.minecraft.util.PacketByteBuf;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+public class ServerNetworkEvents {
+	/**
+	 * Called when the server receives a {@link CustomPayloadC2SPacket}.
+	 * Useful when making server side companion mods for client side mods.
+	 */
+	public static final Event<CustomPayload> CUSTOM_PAYLOAD = EventFactory.createArrayBacked(CustomPayload.class, listeners -> (channel, data) -> {
+		for (CustomPayload callback : listeners) {
+			callback.onCustomPayload(channel, data);
+		}
+	});
+
+	public interface CustomPayload {
+		void onCustomPayload(String channel, PacketByteBuf data);
+	}
+}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerNetworkEvents.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/api/event/lifecycle/v1/ServerNetworkEvents.java
@@ -33,6 +33,7 @@ public class ServerNetworkEvents {
 		}
 	});
 
+	@FunctionalInterface
 	public interface CustomPayload {
 		void onCustomPayload(String channel, PacketByteBuf data);
 	}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MixinServerPlayNetworkHandler.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/MixinServerPlayNetworkHandler.java
@@ -25,9 +25,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.network.ClientConnection;
+import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerNetworkEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerPlayerEvents;
 
 @Mixin(ServerPlayNetworkHandler.class)
@@ -43,8 +45,13 @@ public class MixinServerPlayNetworkHandler {
 	@Final
 	private MinecraftServer server;
 
-	@Inject(at = @At("RETURN"), method = "disconnect")
+	@Inject(at = @At("HEAD"), method = "disconnect")
 	public void onPlayerDisconnect(String reason, CallbackInfo info) {
 		ServerPlayerEvents.DISCONNECT.invoker().playerDisconnect(this.connection, this.player, this.server);
+	}
+
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/util/GameEngine;)V", shift = At.Shift.AFTER), method = "onCustomPayload")
+	public void onCustomPayload(CustomPayloadC2SPacket packet, CallbackInfo ci) {
+		ServerNetworkEvents.CUSTOM_PAYLOAD.invoker().onCustomPayload(packet.method_5761(), packet.method_5763());
 	}
 }

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MixinClientPlayNetworkHandler.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MixinClientPlayNetworkHandler.java
@@ -1,0 +1,22 @@
+package net.fabricmc.fabric.mixin.event.lifecycle.client;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientNetworkEvents;
+
+@Environment(EnvType.CLIENT)
+@Mixin(ClientPlayNetworkHandler.class)
+public class MixinClientPlayNetworkHandler {
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/util/GameEngine;)V", shift = At.Shift.AFTER), method = "onCustomPayload")
+	public void handleCustomPayload(CustomPayloadS2CPacket packet, CallbackInfo ci) {
+		ClientNetworkEvents.CUSTOM_PAYLOAD.invoker().onCustomPayload(packet.method_5444(), packet.getData());
+	}
+}

--- a/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MixinClientPlayNetworkHandler.java
+++ b/fabric-lifecycle-events-v1/src/main/java/net/fabricmc/fabric/mixin/event/lifecycle/client/MixinClientPlayNetworkHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.event.lifecycle.client;
 
 import org.spongepowered.asm.mixin.Mixin;

--- a/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.mixins.json
+++ b/fabric-lifecycle-events-v1/src/main/resources/fabric-lifecycle-events-v1.mixins.json
@@ -19,7 +19,8 @@
     "client.MixinGameOptions",
     "client.MixinIntegratedServer",
     "client.MixinItemStack",
-    "client.MixinMinecraftClient"
+    "client.MixinMinecraftClient",
+    "client.MixinClientPlayNetworkHandler"
   ],
   "server": [
     "server.MixinDedicatedServer"

--- a/fabric-networking-v0/build.gradle
+++ b/fabric-networking-v0/build.gradle
@@ -1,5 +1,5 @@
 archivesBaseName = "fabric-networking-v0"
-version = getSubprojectVersion(project, "0.1.0")
+version = getSubprojectVersion(project, "0.1.1")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')

--- a/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinServerPlayNetworkHandler.java
+++ b/fabric-networking-v0/src/main/java/net/fabricmc/fabric/mixin/network/MixinServerPlayNetworkHandler.java
@@ -18,6 +18,8 @@ package net.fabricmc.fabric.mixin.network;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.entity.player.PlayerEntity;
@@ -36,10 +38,9 @@ public class MixinServerPlayNetworkHandler implements PacketContext {
 	@Shadow
 	public ServerPlayerEntity player;
 
+	@Inject(method = "onCustomPayload", at = @At("HEAD"), cancellable = true)
 	public void onCustomPayload(CustomPayloadC2SPacket packet, CallbackInfo info) {
-		String channel = ((CustomPayloadPacketAccessor) packet).getChannel();
-
-		if (((ServerSidePacketRegistryImpl) ServerSidePacketRegistry.INSTANCE).accept(channel, this, ((CustomPayloadPacketAccessor) packet)::getData)) {
+		if (((ServerSidePacketRegistryImpl) ServerSidePacketRegistry.INSTANCE).accept(((CustomPayloadPacketAccessor) packet).getChannel(), this, ((CustomPayloadPacketAccessor) packet)::getData)) {
 			info.cancel();
 		}
 	}


### PR DESCRIPTION
Added custom payload events that fire every time a server or client receives a `CustomPayloadA2BPacket` (replace A and B with client and server in any order and consider A != B). This data is read-only, as data in packets should never be modified. Since custom payload packets only hold the data and channel, the entire packet instance is not provided, but the channel and data are provided. This allows modders to create server-side or client-side companion mods for their other sided variant. E.g.: spout, we and wecui, etc.

~~in simple terms it's just a port of `PluginChannelListener` from liteloader but it's for both the server and client~~

also fixes a networking bug

if you, the person reading this, are a legacy fabric discord admin, then please create a bot and a webhook in #general and send me the bot token and webhook url. perms: 83968 (send messages, read history, embed links).  
don't squash this pls kthx it's only *two* commits