### PR TITLE
Don't Require 1.8.9 for Base (Event)

### DIFF
--- a/legacy-fabric-api-base/src/main/resources/fabric.mod.json
+++ b/legacy-fabric-api-base/src/main/resources/fabric.mod.json
@@ -16,7 +16,7 @@
     "FabricMC"
   ],
   "depends": {
-    "minecraft": "1.8.x"
+    "fabricloader": ">=0.4.0"
   },
   "description": "Shared hooks used by other api modules"
 }


### PR DESCRIPTION
The Base Event class is Minecraft-agnostic.