### PR TITLE
fix command error output

### DIFF
--- a/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/ChildCommandElementExecutor.java
+++ b/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/ChildCommandElementExecutor.java
@@ -213,10 +213,10 @@ public class ChildCommandElementExecutor extends CommandElement implements Comma
 
 				if (ex instanceof ArgumentParseException.WithUsage) {
 					// This indicates a previous child failed, so we just prepend our child
-					throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + ((ArgumentParseException.WithUsage) ex).getUsage().computeValue()));
+					throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + ((ArgumentParseException.WithUsage) ex).getUsage().asUnformattedString()));
 				}
 
-				throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + mapping.getCallable().getUsage(source).computeValue()));
+				throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + mapping.getCallable().getUsage(source).asUnformattedString()));
 			}
 		} else {
 			// Not a child, so let's continue with the fallback.

--- a/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/ChildCommandElementExecutor.java
+++ b/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/ChildCommandElementExecutor.java
@@ -213,10 +213,10 @@ public class ChildCommandElementExecutor extends CommandElement implements Comma
 
 				if (ex instanceof ArgumentParseException.WithUsage) {
 					// This indicates a previous child failed, so we just prepend our child
-					throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + ((ArgumentParseException.WithUsage) ex).getUsage()));
+					throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + ((ArgumentParseException.WithUsage) ex).getUsage().computeValue()));
 				}
 
-				throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + mapping.getCallable().getUsage(source)));
+				throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + mapping.getCallable().getUsage(source).computeValue()));
 			}
 		} else {
 			// Not a child, so let's continue with the fallback.

--- a/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/CommandArgs.java
+++ b/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/CommandArgs.java
@@ -82,7 +82,7 @@ public final class CommandArgs {
 	 */
 	public String peek() throws ArgumentParseException {
 		if (!this.hasNext()) {
-			throw this.createError(new LiteralText("Not enough arguments"));
+			throw this.createError(new LiteralText("Not enough arguments!"));
 		}
 
 		return this.args.get(this.index + 1).getValue();

--- a/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/CommandElement.java
+++ b/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/CommandElement.java
@@ -125,7 +125,7 @@ public abstract class CommandElement {
 	 * @return The formatted usage
 	 */
 	public Text getUsage(PermissibleCommandSource src) {
-		return this.getKey() == null ? new LiteralText("") : new LiteralText("<" + this.getKey() + ">");
+		return this.getKey() == null ? new LiteralText("") : new LiteralText("<" + this.getKey().computeValue() + ">");
 	}
 
 	public MinecraftServer getServer() {

--- a/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/CommandElement.java
+++ b/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/CommandElement.java
@@ -125,7 +125,7 @@ public abstract class CommandElement {
 	 * @return The formatted usage
 	 */
 	public Text getUsage(PermissibleCommandSource src) {
-		return this.getKey() == null ? new LiteralText("") : new LiteralText("<" + this.getKey().computeValue() + ">");
+		return this.getKey() == null ? new LiteralText("") : new LiteralText("<" + this.getKey().asUnformattedString() + ">");
 	}
 
 	public MinecraftServer getServer() {

--- a/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/spec/CommandSpec.java
+++ b/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/spec/CommandSpec.java
@@ -450,7 +450,7 @@ public final class CommandSpec implements CommandCallable {
 		Preconditions.checkNotNull(source, "source");
 		StringBuilder builder = new StringBuilder();
 		this.getShortDescription(source).ifPresent((a) -> builder.append(a.asUnformattedString()).append("\n"));
-		builder.append(this.getUsage(source));
+		builder.append(this.getUsage(source).computeValue());
 		this.getExtendedDescription(source).ifPresent((a) -> builder.append(a.asUnformattedString()).append("\n"));
 		return Optional.of(new LiteralText(builder.toString()));
 	}

--- a/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/spec/CommandSpec.java
+++ b/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/spec/CommandSpec.java
@@ -450,7 +450,7 @@ public final class CommandSpec implements CommandCallable {
 		Preconditions.checkNotNull(source, "source");
 		StringBuilder builder = new StringBuilder();
 		this.getShortDescription(source).ifPresent((a) -> builder.append(a.asUnformattedString()).append("\n"));
-		builder.append(this.getUsage(source).computeValue());
+		builder.append(this.getUsage(source).asUnformattedString());
 		this.getExtendedDescription(source).ifPresent((a) -> builder.append(a.asUnformattedString()).append("\n"));
 		return Optional.of(new LiteralText(builder.toString()));
 	}

--- a/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandManagerImpl.java
+++ b/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandManagerImpl.java
@@ -131,7 +131,7 @@ public class CommandManagerImpl implements CommandManager {
 							usage = mapping.get().getCallable().getUsage(source);
 						}
 
-						source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", argSplit[0], usage.computeValue()))));
+						source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", argSplit[0], usage.asUnformattedString()))));
 					}
 				}
 			}

--- a/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandManagerImpl.java
+++ b/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandManagerImpl.java
@@ -131,7 +131,7 @@ public class CommandManagerImpl implements CommandManager {
 							usage = mapping.get().getCallable().getUsage(source);
 						}
 
-						source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", argSplit[0], usage))));
+						source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", argSplit[0], usage.computeValue()))));
 					}
 				}
 			}

--- a/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandWrapper.java
+++ b/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandWrapper.java
@@ -92,7 +92,7 @@ public class CommandWrapper extends AbstractCommand {
 						usage = this.mapping.getCallable().getUsage((PermissibleCommandSource) source);
 					}
 
-					source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", this.getCommandName(), usage.computeValue()))));
+					source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", this.getCommandName(), usage.asUnformattedString()))));
 				}
 			}
 		} catch (Throwable t) {

--- a/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandWrapper.java
+++ b/1.12.2/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandWrapper.java
@@ -92,7 +92,7 @@ public class CommandWrapper extends AbstractCommand {
 						usage = this.mapping.getCallable().getUsage((PermissibleCommandSource) source);
 					}
 
-					source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", this.getCommandName(), usage))));
+					source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", this.getCommandName(), usage.computeValue()))));
 				}
 			}
 		} catch (Throwable t) {

--- a/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/ChildCommandElementExecutor.java
+++ b/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/ChildCommandElementExecutor.java
@@ -213,10 +213,10 @@ public class ChildCommandElementExecutor extends CommandElement implements Comma
 
 				if (ex instanceof ArgumentParseException.WithUsage) {
 					// This indicates a previous child failed, so we just prepend our child
-					throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + ((ArgumentParseException.WithUsage) ex).getUsage().computeValue()));
+					throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + ((ArgumentParseException.WithUsage) ex).getUsage().asUnformattedString()));
 				}
 
-				throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + mapping.getCallable().getUsage(source).computeValue()));
+				throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + mapping.getCallable().getUsage(source).asUnformattedString()));
 			}
 		} else {
 			// Not a child, so let's continue with the fallback.

--- a/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/ChildCommandElementExecutor.java
+++ b/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/ChildCommandElementExecutor.java
@@ -213,10 +213,10 @@ public class ChildCommandElementExecutor extends CommandElement implements Comma
 
 				if (ex instanceof ArgumentParseException.WithUsage) {
 					// This indicates a previous child failed, so we just prepend our child
-					throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + ((ArgumentParseException.WithUsage) ex).getUsage()));
+					throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + ((ArgumentParseException.WithUsage) ex).getUsage().computeValue()));
 				}
 
-				throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + mapping.getCallable().getUsage(source)));
+				throw new ArgumentParseException.WithUsage(ex, new LiteralText(key + " " + mapping.getCallable().getUsage(source).computeValue()));
 			}
 		} else {
 			// Not a child, so let's continue with the fallback.

--- a/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/CommandArgs.java
+++ b/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/CommandArgs.java
@@ -82,7 +82,7 @@ public final class CommandArgs {
 	 */
 	public String peek() throws ArgumentParseException {
 		if (!this.hasNext()) {
-			throw this.createError(new LiteralText("Not enough arguments"));
+			throw this.createError(new LiteralText("Not enough arguments!"));
 		}
 
 		return this.args.get(this.index + 1).getValue();

--- a/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/CommandElement.java
+++ b/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/CommandElement.java
@@ -120,6 +120,6 @@ public abstract class CommandElement {
 	 * @return The formatted usage
 	 */
 	public Text getUsage(PermissibleCommandSource src) {
-		return this.getKey() == null ? new LiteralText("") : new LiteralText("<" + this.getKey() + ">");
+		return this.getKey() == null ? new LiteralText("") : new LiteralText("<" + this.getKey().computeValue() + ">");
 	}
 }

--- a/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/CommandElement.java
+++ b/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/args/CommandElement.java
@@ -120,6 +120,6 @@ public abstract class CommandElement {
 	 * @return The formatted usage
 	 */
 	public Text getUsage(PermissibleCommandSource src) {
-		return this.getKey() == null ? new LiteralText("") : new LiteralText("<" + this.getKey().computeValue() + ">");
+		return this.getKey() == null ? new LiteralText("") : new LiteralText("<" + this.getKey().asUnformattedString() + ">");
 	}
 }

--- a/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/spec/CommandSpec.java
+++ b/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/spec/CommandSpec.java
@@ -449,7 +449,7 @@ public final class CommandSpec implements CommandCallable {
 		Preconditions.checkNotNull(source, "source");
 		StringBuilder builder = new StringBuilder();
 		this.getShortDescription(source).ifPresent((a) -> builder.append(a.asUnformattedString()).append("\n"));
-		builder.append(this.getUsage(source));
+		builder.append(this.getUsage(source).computeValue());
 		this.getExtendedDescription(source).ifPresent((a) -> builder.append(a.asUnformattedString()).append("\n"));
 		return Optional.of(new LiteralText(builder.toString()));
 	}

--- a/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/spec/CommandSpec.java
+++ b/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/api/command/v2/lib/sponge/spec/CommandSpec.java
@@ -449,7 +449,7 @@ public final class CommandSpec implements CommandCallable {
 		Preconditions.checkNotNull(source, "source");
 		StringBuilder builder = new StringBuilder();
 		this.getShortDescription(source).ifPresent((a) -> builder.append(a.asUnformattedString()).append("\n"));
-		builder.append(this.getUsage(source).computeValue());
+		builder.append(this.getUsage(source).asUnformattedString());
 		this.getExtendedDescription(source).ifPresent((a) -> builder.append(a.asUnformattedString()).append("\n"));
 		return Optional.of(new LiteralText(builder.toString()));
 	}

--- a/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandManagerImpl.java
+++ b/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandManagerImpl.java
@@ -131,7 +131,7 @@ public class CommandManagerImpl implements CommandManager {
 							usage = mapping.get().getCallable().getUsage(source);
 						}
 
-						source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", argSplit[0], usage.computeValue()))));
+						source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", argSplit[0], usage.asUnformattedString()))));
 					}
 				}
 			}

--- a/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandManagerImpl.java
+++ b/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandManagerImpl.java
@@ -131,7 +131,7 @@ public class CommandManagerImpl implements CommandManager {
 							usage = mapping.get().getCallable().getUsage(source);
 						}
 
-						source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", argSplit[0], usage))));
+						source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", argSplit[0], usage.computeValue()))));
 					}
 				}
 			}

--- a/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandWrapper.java
+++ b/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandWrapper.java
@@ -89,7 +89,7 @@ public class CommandWrapper extends AbstractCommand {
 						usage = this.mapping.getCallable().getUsage((PermissibleCommandSource) source);
 					}
 
-					source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", this.getCommandName(), usage))));
+					source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", this.getCommandName(), usage.computeValue()))));
 				}
 			}
 		} catch (Throwable t) {

--- a/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandWrapper.java
+++ b/1.8.9/legacy-fabric-command-api-v2/src/main/java/net/legacyfabric/fabric/impl/command/CommandWrapper.java
@@ -89,7 +89,7 @@ public class CommandWrapper extends AbstractCommand {
 						usage = this.mapping.getCallable().getUsage((PermissibleCommandSource) source);
 					}
 
-					source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", this.getCommandName(), usage.computeValue()))));
+					source.sendMessage(CommandMessageFormatting.error(new LiteralText(String.format("Usage: /%s %s", this.getCommandName(), usage.asUnformattedString()))));
 				}
 			}
 		} catch (Throwable t) {


### PR DESCRIPTION
Replace usages of `Text.toString()` with `Text.computeValue()`

With test command `/modmetadata` (omitting argument to cause an error)

Current behaviour:
![image](https://github.com/Legacy-Fabric/fabric/assets/32882447/1f3bee69-2b7e-4145-8573-7f2782487a75)

After changes:
![image](https://github.com/Legacy-Fabric/fabric/assets/32882447/cf764733-adab-417b-8694-70a19cf8e37b)

