### PR TITLE
Fix crash on Loader 0.15+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.parallel=true
 
 base_version = 1.9.2
-loader_version = 0.14.22
+loader_version = 0.15.7
 yarn_mappings_build = 530
 
 ## Module versions
@@ -18,6 +18,6 @@ legacy-fabric-lifecycle-events-v1.version = 1.0.1
 legacy-fabric-logger-api-v1.version = 1.0.4
 legacy-fabric-networking-api-v1.version = 2.0.1
 legacy-fabric-permissions-api-v1.version = 1.0.1
-legacy-fabric-registry-sync-api-v1.version = 2.1.0
+legacy-fabric-registry-sync-api-v1.version = 2.2.0
 legacy-fabric-rendering-api-v1.version = 1.0.0
 legacy-fabric-resource-loader-v1.version = 2.1.1

--- a/legacy-fabric-registry-sync-api-v1/common/src/main/java/net/legacyfabric/fabric/api/registry/v1/RegistryHelper.java
+++ b/legacy-fabric-registry-sync-api-v1/common/src/main/java/net/legacyfabric/fabric/api/registry/v1/RegistryHelper.java
@@ -28,14 +28,13 @@ import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.item.Item;
 import net.minecraft.world.biome.Biome;
 
-import net.fabricmc.tinyremapper.extension.mixin.common.data.Pair;
-
 import net.legacyfabric.fabric.api.event.Event;
 import net.legacyfabric.fabric.api.event.EventFactory;
 import net.legacyfabric.fabric.api.util.BeforeMC;
 import net.legacyfabric.fabric.api.util.Identifier;
 import net.legacyfabric.fabric.api.util.SinceMC;
 import net.legacyfabric.fabric.impl.registry.RegistryHelperImpl;
+import net.legacyfabric.fabric.impl.registry.util.BiomePair;
 
 /**
  * Allows registration of Blocks, Items, Block Entity Classes, Status Effects and Enchantments.
@@ -209,7 +208,7 @@ public final class RegistryHelper {
 	 * @return The biomes registered
 	 */
 	@BeforeMC("1.9")
-	public static Pair<Biome, Biome> registerBiomeWithMutatedVariant(
+	public static BiomePair registerBiomeWithMutatedVariant(
 			EntryCreator<Biome> parentBiome, Identifier parentId,
 			EntryCreator<Biome> mutatedBiome, Identifier mutatedId
 	) {

--- a/legacy-fabric-registry-sync-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/registry/util/BiomePair.java
+++ b/legacy-fabric-registry-sync-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/registry/util/BiomePair.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.impl.registry.util;
+
+import net.minecraft.world.biome.Biome;
+
+public class BiomePair {
+	private final Biome parent, mutated;
+
+	public BiomePair(Biome parent, Biome mutated) {
+		this.parent = parent;
+		this.mutated = mutated;
+	}
+
+	public Biome getParent() {
+		return parent;
+	}
+
+	public Biome getMutated() {
+		return mutated;
+	}
+}

--- a/legacy-fabric-registry-sync-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/registry/util/NumericalIdPair.java
+++ b/legacy-fabric-registry-sync-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/registry/util/NumericalIdPair.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.impl.registry.util;
+
+public class NumericalIdPair {
+	private final int main, secondary;
+
+	public NumericalIdPair(int main, int secondary) {
+		this.main = main;
+		this.secondary = secondary;
+	}
+
+	public int getMain() {
+		return main;
+	}
+
+	public int getSecondary() {
+		return secondary;
+	}
+}


### PR DESCRIPTION
Stop depending on loader shaded libraries.

Also, should we move to MixinExtras and drop support for loader 0.14?