### PR TITLE
Defer sponge command registration

### DIFF
--- a/legacy-fabric-command-api-v1/common/src/main/java/net/legacyfabric/fabric/api/registry/CommandRegistrationCallback.java
+++ b/legacy-fabric-command-api-v1/common/src/main/java/net/legacyfabric/fabric/api/registry/CommandRegistrationCallback.java
@@ -1,0 +1,23 @@
+package net.legacyfabric.fabric.api.registry;
+
+import net.legacyfabric.fabric.api.event.Event;
+import net.legacyfabric.fabric.api.event.EventFactory;
+
+/**
+ * An event for registering commands to the {@link CommandRegistry}
+ */
+@FunctionalInterface
+public interface CommandRegistrationCallback {
+	Event<CommandRegistrationCallback> EVENT = EventFactory.createArrayBacked(CommandRegistrationCallback.class, listeners -> registry -> {
+		for (CommandRegistrationCallback registrar : listeners) {
+			registrar.register(registry);
+		}
+	});
+
+	/**
+	 * Register your commands here.
+	 *
+	 * @param registry The command registry
+	 */
+	void register(CommandRegistry registry);
+}

--- a/legacy-fabric-command-api-v1/common/src/main/java/net/legacyfabric/fabric/api/registry/CommandRegistrationCallback.java
+++ b/legacy-fabric-command-api-v1/common/src/main/java/net/legacyfabric/fabric/api/registry/CommandRegistrationCallback.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.api.registry;
 
 import net.legacyfabric.fabric.api.event.Event;

--- a/legacy-fabric-command-api-v1/common/src/main/java/net/legacyfabric/fabric/api/registry/CommandRegistrationCallback.java
+++ b/legacy-fabric-command-api-v1/common/src/main/java/net/legacyfabric/fabric/api/registry/CommandRegistrationCallback.java
@@ -21,7 +21,7 @@ import net.legacyfabric.fabric.api.event.Event;
 import net.legacyfabric.fabric.api.event.EventFactory;
 
 /**
- * An event for registering commands to the {@link CommandRegistry}
+ * An event for registering commands to the {@link CommandRegistry}.
  */
 @FunctionalInterface
 public interface CommandRegistrationCallback {

--- a/legacy-fabric-command-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/command/CommandInitializer.java
+++ b/legacy-fabric-command-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/command/CommandInitializer.java
@@ -17,6 +17,9 @@
 
 package net.legacyfabric.fabric.impl.command;
 
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
+import net.legacyfabric.fabric.api.registry.CommandRegistry;
+
 import net.minecraft.server.command.CommandManager;
 
 import net.fabricmc.api.ModInitializer;
@@ -27,6 +30,8 @@ public class CommandInitializer implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		ServerLifecycleEvents.SERVER_STARTING.register(server -> {
+			CommandRegistrationCallback.EVENT.invoker().register(CommandRegistry.INSTANCE);
+
 			boolean dedicated = server.isDedicated();
 			CommandManager manager = (CommandManager) server.getCommandManager();
 			CommandRegistryImpl.getCommandMap().forEach((command, commandSide) -> {

--- a/legacy-fabric-command-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/command/CommandInitializer.java
+++ b/legacy-fabric-command-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/command/CommandInitializer.java
@@ -17,14 +17,13 @@
 
 package net.legacyfabric.fabric.impl.command;
 
-import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
-import net.legacyfabric.fabric.api.registry.CommandRegistry;
-
 import net.minecraft.server.command.CommandManager;
 
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
+import net.legacyfabric.fabric.api.registry.CommandRegistry;
 
 public class CommandInitializer implements ModInitializer {
 	@Override

--- a/legacy-fabric-command-api-v2/1.12.2/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
+++ b/legacy-fabric-command-api-v2/1.12.2/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
@@ -22,15 +22,18 @@ import net.fabricmc.api.DedicatedServerModInitializer;
 
 import net.legacyfabric.fabric.api.command.v2.CommandRegistrar;
 import net.legacyfabric.fabric.api.command.v2.lib.sponge.CommandManager;
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
 import net.legacyfabric.fabric.api.registry.CommandRegistry;
 
 public class ImplInit implements DedicatedServerModInitializer, ClientModInitializer, CommandRegistrar {
 	@Override
 	public void register(CommandManager manager, boolean dedicated) {
-		CommandRegistrar.EVENT.invoker().register(manager, dedicated);
-		InternalObjects.getCommandManager().getCommands().forEach(mapping -> {
-			CommandWrapper wrapper = new CommandWrapper(mapping);
-			CommandRegistry.INSTANCE.register(wrapper);
+		CommandRegistrationCallback.EVENT.register(registry -> {
+			CommandRegistrar.EVENT.invoker().register(manager, dedicated);
+			InternalObjects.getCommandManager().getCommands().forEach(mapping -> {
+				CommandWrapper wrapper = new CommandWrapper(mapping);
+				CommandRegistry.INSTANCE.register(wrapper);
+			});
 		});
 	}
 

--- a/legacy-fabric-command-api-v2/1.12.2/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
+++ b/legacy-fabric-command-api-v2/1.12.2/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
@@ -23,7 +23,6 @@ import net.fabricmc.api.DedicatedServerModInitializer;
 import net.legacyfabric.fabric.api.command.v2.CommandRegistrar;
 import net.legacyfabric.fabric.api.command.v2.lib.sponge.CommandManager;
 import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
-import net.legacyfabric.fabric.api.registry.CommandRegistry;
 
 public class ImplInit implements DedicatedServerModInitializer, ClientModInitializer, CommandRegistrar {
 	@Override
@@ -32,7 +31,7 @@ public class ImplInit implements DedicatedServerModInitializer, ClientModInitial
 			CommandRegistrar.EVENT.invoker().register(manager, dedicated);
 			InternalObjects.getCommandManager().getCommands().forEach(mapping -> {
 				CommandWrapper wrapper = new CommandWrapper(mapping);
-				CommandRegistry.INSTANCE.register(wrapper);
+				registry.register(wrapper);
 			});
 		});
 	}

--- a/legacy-fabric-command-api-v2/1.6.4/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
+++ b/legacy-fabric-command-api-v2/1.6.4/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
@@ -22,15 +22,18 @@ import net.fabricmc.api.DedicatedServerModInitializer;
 
 import net.legacyfabric.fabric.api.command.v2.CommandRegistrar;
 import net.legacyfabric.fabric.api.command.v2.lib.sponge.CommandManager;
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
 import net.legacyfabric.fabric.api.registry.CommandRegistry;
 
 public class ImplInit implements DedicatedServerModInitializer, ClientModInitializer, CommandRegistrar {
 	@Override
 	public void register(CommandManager manager, boolean dedicated) {
-		CommandRegistrar.EVENT.invoker().register(manager, dedicated);
-		InternalObjects.getCommandManager().getCommands().forEach(mapping -> {
-			CommandWrapper wrapper = new CommandWrapper(mapping);
-			CommandRegistry.INSTANCE.register(wrapper);
+		CommandRegistrationCallback.EVENT.register(registry -> {
+			CommandRegistrar.EVENT.invoker().register(manager, dedicated);
+			InternalObjects.getCommandManager().getCommands().forEach(mapping -> {
+				CommandWrapper wrapper = new CommandWrapper(mapping);
+				CommandRegistry.INSTANCE.register(wrapper);
+			});
 		});
 	}
 

--- a/legacy-fabric-command-api-v2/1.6.4/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
+++ b/legacy-fabric-command-api-v2/1.6.4/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
@@ -23,7 +23,6 @@ import net.fabricmc.api.DedicatedServerModInitializer;
 import net.legacyfabric.fabric.api.command.v2.CommandRegistrar;
 import net.legacyfabric.fabric.api.command.v2.lib.sponge.CommandManager;
 import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
-import net.legacyfabric.fabric.api.registry.CommandRegistry;
 
 public class ImplInit implements DedicatedServerModInitializer, ClientModInitializer, CommandRegistrar {
 	@Override
@@ -32,7 +31,7 @@ public class ImplInit implements DedicatedServerModInitializer, ClientModInitial
 			CommandRegistrar.EVENT.invoker().register(manager, dedicated);
 			InternalObjects.getCommandManager().getCommands().forEach(mapping -> {
 				CommandWrapper wrapper = new CommandWrapper(mapping);
-				CommandRegistry.INSTANCE.register(wrapper);
+				registry.register(wrapper);
 			});
 		});
 	}

--- a/legacy-fabric-command-api-v2/1.7.10/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
+++ b/legacy-fabric-command-api-v2/1.7.10/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
@@ -22,15 +22,18 @@ import net.fabricmc.api.DedicatedServerModInitializer;
 
 import net.legacyfabric.fabric.api.command.v2.CommandRegistrar;
 import net.legacyfabric.fabric.api.command.v2.lib.sponge.CommandManager;
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
 import net.legacyfabric.fabric.api.registry.CommandRegistry;
 
 public class ImplInit implements DedicatedServerModInitializer, ClientModInitializer, CommandRegistrar {
 	@Override
 	public void register(CommandManager manager, boolean dedicated) {
-		CommandRegistrar.EVENT.invoker().register(manager, dedicated);
-		InternalObjects.getCommandManager().getCommands().forEach(mapping -> {
-			CommandWrapper wrapper = new CommandWrapper(mapping);
-			CommandRegistry.INSTANCE.register(wrapper);
+		CommandRegistrationCallback.EVENT.register(registry -> {
+			CommandRegistrar.EVENT.invoker().register(manager, dedicated);
+			InternalObjects.getCommandManager().getCommands().forEach(mapping -> {
+				CommandWrapper wrapper = new CommandWrapper(mapping);
+				CommandRegistry.INSTANCE.register(wrapper);
+			});
 		});
 	}
 

--- a/legacy-fabric-command-api-v2/1.7.10/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
+++ b/legacy-fabric-command-api-v2/1.7.10/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
@@ -23,7 +23,6 @@ import net.fabricmc.api.DedicatedServerModInitializer;
 import net.legacyfabric.fabric.api.command.v2.CommandRegistrar;
 import net.legacyfabric.fabric.api.command.v2.lib.sponge.CommandManager;
 import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
-import net.legacyfabric.fabric.api.registry.CommandRegistry;
 
 public class ImplInit implements DedicatedServerModInitializer, ClientModInitializer, CommandRegistrar {
 	@Override
@@ -32,7 +31,7 @@ public class ImplInit implements DedicatedServerModInitializer, ClientModInitial
 			CommandRegistrar.EVENT.invoker().register(manager, dedicated);
 			InternalObjects.getCommandManager().getCommands().forEach(mapping -> {
 				CommandWrapper wrapper = new CommandWrapper(mapping);
-				CommandRegistry.INSTANCE.register(wrapper);
+				registry.register(wrapper);
 			});
 		});
 	}

--- a/legacy-fabric-command-api-v2/1.8.9/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
+++ b/legacy-fabric-command-api-v2/1.8.9/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
@@ -22,15 +22,18 @@ import net.fabricmc.api.DedicatedServerModInitializer;
 
 import net.legacyfabric.fabric.api.command.v2.CommandRegistrar;
 import net.legacyfabric.fabric.api.command.v2.lib.sponge.CommandManager;
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
 import net.legacyfabric.fabric.api.registry.CommandRegistry;
 
 public class ImplInit implements DedicatedServerModInitializer, ClientModInitializer, CommandRegistrar {
 	@Override
 	public void register(CommandManager manager, boolean dedicated) {
-		CommandRegistrar.EVENT.invoker().register(manager, dedicated);
-		InternalObjects.getCommandManager().getCommands().forEach(mapping -> {
-			CommandWrapper wrapper = new CommandWrapper(mapping);
-			CommandRegistry.INSTANCE.register(wrapper);
+		CommandRegistrationCallback.EVENT.register(registry -> {
+			CommandRegistrar.EVENT.invoker().register(manager, dedicated);
+			InternalObjects.getCommandManager().getCommands().forEach(mapping -> {
+				CommandWrapper wrapper = new CommandWrapper(mapping);
+				CommandRegistry.INSTANCE.register(wrapper);
+			});
 		});
 	}
 

--- a/legacy-fabric-command-api-v2/1.8.9/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
+++ b/legacy-fabric-command-api-v2/1.8.9/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java
@@ -23,7 +23,6 @@ import net.fabricmc.api.DedicatedServerModInitializer;
 import net.legacyfabric.fabric.api.command.v2.CommandRegistrar;
 import net.legacyfabric.fabric.api.command.v2.lib.sponge.CommandManager;
 import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
-import net.legacyfabric.fabric.api.registry.CommandRegistry;
 
 public class ImplInit implements DedicatedServerModInitializer, ClientModInitializer, CommandRegistrar {
 	@Override
@@ -32,7 +31,7 @@ public class ImplInit implements DedicatedServerModInitializer, ClientModInitial
 			CommandRegistrar.EVENT.invoker().register(manager, dedicated);
 			InternalObjects.getCommandManager().getCommands().forEach(mapping -> {
 				CommandWrapper wrapper = new CommandWrapper(mapping);
-				CommandRegistry.INSTANCE.register(wrapper);
+				registry.register(wrapper);
 			});
 		});
 	}

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
@@ -20,13 +20,15 @@ package net.legacyfabric.fabric.test.command;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.logger.v1.Logger;
-import net.legacyfabric.fabric.api.registry.CommandRegistry;
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
 
 public class CommandV1Test implements ModInitializer {
 	public static final Logger LOGGER = Logger.get("LegacyFabricAPI", "Test", "CommandV1Test");
 
 	@Override
 	public void onInitialize() {
-		CommandRegistry.INSTANCE.register(new ModMetadataCommandV1());
+		CommandRegistrationCallback.EVENT.register(registry -> {
+			registry.register(new ModMetadataCommandV1());
+		});
 	}
 }

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
@@ -17,12 +17,9 @@
 
 package net.legacyfabric.fabric.test.command;
 
-import java.util.Objects;
-
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.LiteralText;
 
-import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 
@@ -45,10 +42,8 @@ public class ModMetadataCommand {
 		);
 	}
 
-	private static final boolean useStyle = !Objects.equals(FabricLoader.getInstance().getModContainer("minecraft").get().getMetadata().getVersion().getFriendlyString(), "1.8");
-
 	private static CommandResult execute(PermissibleCommandSource source, CommandContext ctx) throws CommandException {
-		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("mod not found")));
+		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("Couldn't find Mod container")));
 		LiteralText builder = new LiteralText("");
 		builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 		builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
@@ -58,7 +53,7 @@ public class ModMetadataCommand {
 			LiteralText issueText = new LiteralText("");
 			issueText.append("Issues: ");
 			LiteralText issueUrl = new LiteralText(contact.get("issues").get());
-			if (useStyle) issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
+			issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
 			issueText.append(issueUrl);
 			issueText.append("\n");
 			builder.append(issueText);
@@ -68,7 +63,7 @@ public class ModMetadataCommand {
 			LiteralText sourcesText = new LiteralText("");
 			sourcesText.append("Sources: ");
 			LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
-			if (useStyle) sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
+			sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
 			sourcesText.append(sourcesUrl);
 			sourcesText.append("\n");
 			builder.append(sourcesText);

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -22,15 +22,14 @@ import java.util.Optional;
 import net.minecraft.command.AbstractCommand;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.MinecraftServer;
-
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.ModContainer;
-import net.fabricmc.loader.api.metadata.ContactInformation;
-
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Style;
 import net.minecraft.util.Formatting;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ContactInformation;
 
 public class ModMetadataCommandV1 extends AbstractCommand {
 	@Override

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -20,13 +20,17 @@ package net.legacyfabric.fabric.test.command;
 import java.util.Optional;
 
 import net.minecraft.command.AbstractCommand;
-import net.minecraft.command.CommandException;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.MinecraftServer;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ContactInformation;
+
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Style;
+import net.minecraft.util.Formatting;
 
 public class ModMetadataCommandV1 extends AbstractCommand {
 	@Override
@@ -40,40 +44,44 @@ public class ModMetadataCommandV1 extends AbstractCommand {
 	}
 
 	@Override
-	public void method_3279(MinecraftServer minecraftServer, CommandSource commandSource, String[] args) throws CommandException {
+	public void method_3279(MinecraftServer minecraftServer, CommandSource commandSource, String[] args) {
 		if (args.length > 0) {
 			Optional<ModContainer> optionalModContainer = FabricLoader.getInstance().getModContainer(args[0]);
 
 			if (optionalModContainer.isPresent()) {
 				ModContainer container = optionalModContainer.get();
 
-				StringBuilder builder = new StringBuilder();
+				LiteralText builder = new LiteralText("");
 				builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 				builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
 				ContactInformation contact = container.getMetadata().getContact();
 
 				if (contact.get("issues").isPresent()) {
-					StringBuilder issueText = new StringBuilder("");
+					LiteralText issueText = new LiteralText("");
 					issueText.append("Issues: ");
-					StringBuilder issueUrl = new StringBuilder(contact.get("issues").get());
+					LiteralText issueUrl = new LiteralText(contact.get("issues").get());
+					issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
 					issueText.append(issueUrl);
 					issueText.append("\n");
 					builder.append(issueText);
 				}
 
 				if (contact.get("sources").isPresent()) {
-					StringBuilder sourcesText = new StringBuilder("");
+					LiteralText sourcesText = new LiteralText("");
 					sourcesText.append("Sources: ");
-					StringBuilder sourcesUrl = new StringBuilder(contact.get("sources").get());
+					LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
+					sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
 					sourcesText.append(sourcesUrl);
 					sourcesText.append("\n");
 					builder.append(sourcesText);
 				}
 
 				builder.append("Metadata Type: ".concat(container.getMetadata().getType()).concat("\n"));
-				CommandV1Test.LOGGER.info(builder.toString());
+				commandSource.sendMessage(builder);
 			} else {
-				CommandV1Test.LOGGER.error("Couldn't find Mod container for mod id '" + args[0] + "'");
+				LiteralText builder = new LiteralText("Couldn't find Mod container for mod id '" + args[0] + "'");
+				builder.setStyle(new Style().setFormatting(Formatting.RED));
+				commandSource.sendMessage(builder);
 			}
 		}
 	}

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
@@ -20,13 +20,15 @@ package net.legacyfabric.fabric.test.command;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.logger.v1.Logger;
-import net.legacyfabric.fabric.api.registry.CommandRegistry;
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
 
 public class CommandV1Test implements ModInitializer {
 	public static final Logger LOGGER = Logger.get("LegacyFabricAPI", "Test", "CommandV1Test");
 
 	@Override
 	public void onInitialize() {
-		CommandRegistry.INSTANCE.register(new ModMetadataCommandV1());
+		CommandRegistrationCallback.EVENT.register(registry -> {
+			registry.register(new ModMetadataCommandV1());
+		});
 	}
 }

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
@@ -17,12 +17,9 @@
 
 package net.legacyfabric.fabric.test.command;
 
-import java.util.Objects;
-
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.LiteralText;
 
-import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 
@@ -45,10 +42,8 @@ public class ModMetadataCommand {
 		);
 	}
 
-	private static final boolean useStyle = !Objects.equals(FabricLoader.getInstance().getModContainer("minecraft").get().getMetadata().getVersion().getFriendlyString(), "1.8");
-
 	private static CommandResult execute(PermissibleCommandSource source, CommandContext ctx) throws CommandException {
-		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("mod not found")));
+		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("Couldn't find Mod container")));
 		LiteralText builder = new LiteralText("");
 		builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 		builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
@@ -58,7 +53,7 @@ public class ModMetadataCommand {
 			LiteralText issueText = new LiteralText("");
 			issueText.append("Issues: ");
 			LiteralText issueUrl = new LiteralText(contact.get("issues").get());
-			if (useStyle) issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
+			issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
 			issueText.append(issueUrl);
 			issueText.append("\n");
 			builder.append(issueText);
@@ -68,7 +63,7 @@ public class ModMetadataCommand {
 			LiteralText sourcesText = new LiteralText("");
 			sourcesText.append("Sources: ");
 			LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
-			if (useStyle) sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
+			sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
 			sourcesText.append(sourcesUrl);
 			sourcesText.append("\n");
 			builder.append(sourcesText);

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -22,15 +22,14 @@ import java.util.Optional;
 import net.minecraft.command.AbstractCommand;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.MinecraftServer;
-
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.ModContainer;
-import net.fabricmc.loader.api.metadata.ContactInformation;
-
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Style;
 import net.minecraft.util.Formatting;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ContactInformation;
 
 public class ModMetadataCommandV1 extends AbstractCommand {
 	@Override

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -20,13 +20,17 @@ package net.legacyfabric.fabric.test.command;
 import java.util.Optional;
 
 import net.minecraft.command.AbstractCommand;
-import net.minecraft.command.CommandException;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.MinecraftServer;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ContactInformation;
+
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Style;
+import net.minecraft.util.Formatting;
 
 public class ModMetadataCommandV1 extends AbstractCommand {
 	@Override
@@ -40,40 +44,44 @@ public class ModMetadataCommandV1 extends AbstractCommand {
 	}
 
 	@Override
-	public void method_3279(MinecraftServer minecraftServer, CommandSource commandSource, String[] args) throws CommandException {
+	public void method_3279(MinecraftServer minecraftServer, CommandSource commandSource, String[] args) {
 		if (args.length > 0) {
 			Optional<ModContainer> optionalModContainer = FabricLoader.getInstance().getModContainer(args[0]);
 
 			if (optionalModContainer.isPresent()) {
 				ModContainer container = optionalModContainer.get();
 
-				StringBuilder builder = new StringBuilder();
+				LiteralText builder = new LiteralText("");
 				builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 				builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
 				ContactInformation contact = container.getMetadata().getContact();
 
 				if (contact.get("issues").isPresent()) {
-					StringBuilder issueText = new StringBuilder("");
+					LiteralText issueText = new LiteralText("");
 					issueText.append("Issues: ");
-					StringBuilder issueUrl = new StringBuilder(contact.get("issues").get());
+					LiteralText issueUrl = new LiteralText(contact.get("issues").get());
+					issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
 					issueText.append(issueUrl);
 					issueText.append("\n");
 					builder.append(issueText);
 				}
 
 				if (contact.get("sources").isPresent()) {
-					StringBuilder sourcesText = new StringBuilder("");
+					LiteralText sourcesText = new LiteralText("");
 					sourcesText.append("Sources: ");
-					StringBuilder sourcesUrl = new StringBuilder(contact.get("sources").get());
+					LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
+					sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
 					sourcesText.append(sourcesUrl);
 					sourcesText.append("\n");
 					builder.append(sourcesText);
 				}
 
 				builder.append("Metadata Type: ".concat(container.getMetadata().getType()).concat("\n"));
-				CommandV1Test.LOGGER.info(builder.toString());
+				commandSource.sendMessage(builder);
 			} else {
-				CommandV1Test.LOGGER.error("Couldn't find Mod container for mod id '" + args[0] + "'");
+				LiteralText builder = new LiteralText("Couldn't find Mod container for mod id '" + args[0] + "'");
+				builder.setStyle(new Style().setFormatting(Formatting.RED));
+				commandSource.sendMessage(builder);
 			}
 		}
 	}

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
@@ -20,13 +20,15 @@ package net.legacyfabric.fabric.test.command;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.logger.v1.Logger;
-import net.legacyfabric.fabric.api.registry.CommandRegistry;
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
 
 public class CommandV1Test implements ModInitializer {
 	public static final Logger LOGGER = Logger.get("LegacyFabricAPI", "Test", "CommandV1Test");
 
 	@Override
 	public void onInitialize() {
-		CommandRegistry.INSTANCE.register(new ModMetadataCommandV1());
+		CommandRegistrationCallback.EVENT.register(registry -> {
+			registry.register(new ModMetadataCommandV1());
+		});
 	}
 }

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
@@ -17,12 +17,9 @@
 
 package net.legacyfabric.fabric.test.command;
 
-import java.util.Objects;
-
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.LiteralText;
 
-import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 
@@ -45,10 +42,8 @@ public class ModMetadataCommand {
 		);
 	}
 
-	private static final boolean useStyle = !Objects.equals(FabricLoader.getInstance().getModContainer("minecraft").get().getMetadata().getVersion().getFriendlyString(), "1.8");
-
 	private static CommandResult execute(PermissibleCommandSource source, CommandContext ctx) throws CommandException {
-		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("mod not found")));
+		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("Couldn't find Mod container")));
 		LiteralText builder = new LiteralText("");
 		builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 		builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
@@ -58,7 +53,7 @@ public class ModMetadataCommand {
 			LiteralText issueText = new LiteralText("");
 			issueText.append("Issues: ");
 			LiteralText issueUrl = new LiteralText(contact.get("issues").get());
-			if (useStyle) issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
+			issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
 			issueText.append(issueUrl);
 			issueText.append("\n");
 			builder.append(issueText);
@@ -68,7 +63,7 @@ public class ModMetadataCommand {
 			LiteralText sourcesText = new LiteralText("");
 			sourcesText.append("Sources: ");
 			LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
-			if (useStyle) sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
+			sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
 			sourcesText.append(sourcesUrl);
 			sourcesText.append("\n");
 			builder.append(sourcesText);

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -22,15 +22,14 @@ import java.util.Optional;
 import net.minecraft.command.AbstractCommand;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.MinecraftServer;
-
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.ModContainer;
-import net.fabricmc.loader.api.metadata.ContactInformation;
-
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Style;
 import net.minecraft.util.Formatting;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ContactInformation;
 
 public class ModMetadataCommandV1 extends AbstractCommand {
 	@Override

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -20,13 +20,17 @@ package net.legacyfabric.fabric.test.command;
 import java.util.Optional;
 
 import net.minecraft.command.AbstractCommand;
-import net.minecraft.command.CommandException;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.MinecraftServer;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ContactInformation;
+
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Style;
+import net.minecraft.util.Formatting;
 
 public class ModMetadataCommandV1 extends AbstractCommand {
 	@Override
@@ -40,40 +44,44 @@ public class ModMetadataCommandV1 extends AbstractCommand {
 	}
 
 	@Override
-	public void method_3279(MinecraftServer minecraftServer, CommandSource commandSource, String[] args) throws CommandException {
+	public void method_3279(MinecraftServer minecraftServer, CommandSource commandSource, String[] args) {
 		if (args.length > 0) {
 			Optional<ModContainer> optionalModContainer = FabricLoader.getInstance().getModContainer(args[0]);
 
 			if (optionalModContainer.isPresent()) {
 				ModContainer container = optionalModContainer.get();
 
-				StringBuilder builder = new StringBuilder();
+				LiteralText builder = new LiteralText("");
 				builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 				builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
 				ContactInformation contact = container.getMetadata().getContact();
 
 				if (contact.get("issues").isPresent()) {
-					StringBuilder issueText = new StringBuilder("");
+					LiteralText issueText = new LiteralText("");
 					issueText.append("Issues: ");
-					StringBuilder issueUrl = new StringBuilder(contact.get("issues").get());
+					LiteralText issueUrl = new LiteralText(contact.get("issues").get());
+					issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
 					issueText.append(issueUrl);
 					issueText.append("\n");
 					builder.append(issueText);
 				}
 
 				if (contact.get("sources").isPresent()) {
-					StringBuilder sourcesText = new StringBuilder("");
+					LiteralText sourcesText = new LiteralText("");
 					sourcesText.append("Sources: ");
-					StringBuilder sourcesUrl = new StringBuilder(contact.get("sources").get());
+					LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
+					sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
 					sourcesText.append(sourcesUrl);
 					sourcesText.append("\n");
 					builder.append(sourcesText);
 				}
 
 				builder.append("Metadata Type: ".concat(container.getMetadata().getType()).concat("\n"));
-				CommandV1Test.LOGGER.info(builder.toString());
+				commandSource.sendMessage(builder);
 			} else {
-				CommandV1Test.LOGGER.error("Couldn't find Mod container for mod id '" + args[0] + "'");
+				LiteralText builder = new LiteralText("Couldn't find Mod container for mod id '" + args[0] + "'");
+				builder.setStyle(new Style().setFormatting(Formatting.RED));
+				commandSource.sendMessage(builder);
 			}
 		}
 	}

--- a/legacyfabric-api/1.6.4/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
+++ b/legacyfabric-api/1.6.4/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
@@ -20,13 +20,15 @@ package net.legacyfabric.fabric.test.command;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.logger.v1.Logger;
-import net.legacyfabric.fabric.api.registry.CommandRegistry;
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
 
 public class CommandV1Test implements ModInitializer {
 	public static final Logger LOGGER = Logger.get("LegacyFabricAPI", "Test", "CommandV1Test");
 
 	@Override
 	public void onInitialize() {
-		CommandRegistry.INSTANCE.register(new ModMetadataCommandV1());
+		CommandRegistrationCallback.EVENT.register(registry -> {
+			registry.register(new ModMetadataCommandV1());
+		});
 	}
 }

--- a/legacyfabric-api/1.6.4/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
+++ b/legacyfabric-api/1.6.4/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
@@ -17,11 +17,8 @@
 
 package net.legacyfabric.fabric.test.command;
 
-import java.util.Objects;
-
 import net.minecraft.text.ChatMessage;
 
-import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 
@@ -44,10 +41,8 @@ public class ModMetadataCommand {
 		);
 	}
 
-	private static final boolean useStyle = !Objects.equals(FabricLoader.getInstance().getModContainer("minecraft").get().getMetadata().getVersion().getFriendlyString(), "1.8");
-
 	private static CommandResult execute(PermissibleCommandSource source, CommandContext ctx) throws CommandException {
-		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(ChatMessage.createTextMessage("mod not found")));
+		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(ChatMessage.createTextMessage("Couldn't find Mod container")));
 		ChatMessage builder = ChatMessage.createTextMessage("");
 		builder.addText("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 		builder.addText("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));

--- a/legacyfabric-api/1.6.4/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.6.4/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -19,16 +19,14 @@ package net.legacyfabric.fabric.test.command;
 
 import java.util.Optional;
 
-import net.minecraft.text.ChatMessage;
-
-import net.minecraft.util.Formatting;
-
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.command.AbstractCommand;
 import net.minecraft.command.Command;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.CommandSource;
+import net.minecraft.text.ChatMessage;
+import net.minecraft.util.Formatting;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;

--- a/legacyfabric-api/1.6.4/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.6.4/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -19,6 +19,10 @@ package net.legacyfabric.fabric.test.command;
 
 import java.util.Optional;
 
+import net.minecraft.text.ChatMessage;
+
+import net.minecraft.util.Formatting;
+
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.command.AbstractCommand;
@@ -49,33 +53,35 @@ public class ModMetadataCommandV1 extends AbstractCommand {
 			if (optionalModContainer.isPresent()) {
 				ModContainer container = optionalModContainer.get();
 
-				StringBuilder builder = new StringBuilder();
-				builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
-				builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
+				ChatMessage builder = ChatMessage.createTextMessage("");
+				builder.addText("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
+				builder.addText("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
 				ContactInformation contact = container.getMetadata().getContact();
 
 				if (contact.get("issues").isPresent()) {
-					StringBuilder issueText = new StringBuilder("");
-					issueText.append("Issues: ");
-					StringBuilder issueUrl = new StringBuilder(contact.get("issues").get());
-					issueText.append(issueUrl);
-					issueText.append("\n");
-					builder.append(issueText);
+					ChatMessage issueText = ChatMessage.createTextMessage("");
+					issueText.addText("Issues: ");
+					ChatMessage issueUrl = ChatMessage.createTextMessage(contact.get("issues").get());
+					issueText.addUsing(issueUrl);
+					issueText.addText("\n");
+					builder.addUsing(issueText);
 				}
 
 				if (contact.get("sources").isPresent()) {
-					StringBuilder sourcesText = new StringBuilder("");
-					sourcesText.append("Sources: ");
-					StringBuilder sourcesUrl = new StringBuilder(contact.get("sources").get());
-					sourcesText.append(sourcesUrl);
-					sourcesText.append("\n");
-					builder.append(sourcesText);
+					ChatMessage sourcesText = ChatMessage.createTextMessage("");
+					sourcesText.addText("Sources: ");
+					ChatMessage sourcesUrl = ChatMessage.createTextMessage(contact.get("sources").get());
+					sourcesText.addUsing(sourcesUrl);
+					sourcesText.addText("\n");
+					builder.addUsing(sourcesText);
 				}
 
-				builder.append("Metadata Type: ".concat(container.getMetadata().getType()).concat("\n"));
-				CommandV1Test.LOGGER.info(builder.toString());
+				builder.addText("Metadata Type: ".concat(container.getMetadata().getType()).concat("\n"));
+				commandSource.method_5505(builder);
 			} else {
-				CommandV1Test.LOGGER.error("Couldn't find Mod container for mod id '" + args[0] + "'");
+				ChatMessage builder = ChatMessage.createTextMessage("Couldn't find Mod container for mod id '" + args[0] + "'");
+				builder.setColor(Formatting.RED);
+				commandSource.method_5505(builder);
 			}
 		}
 	}

--- a/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
+++ b/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
@@ -20,13 +20,15 @@ package net.legacyfabric.fabric.test.command;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.logger.v1.Logger;
-import net.legacyfabric.fabric.api.registry.CommandRegistry;
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
 
 public class CommandV1Test implements ModInitializer {
 	public static final Logger LOGGER = Logger.get("LegacyFabricAPI", "Test", "CommandV1Test");
 
 	@Override
 	public void onInitialize() {
-		CommandRegistry.INSTANCE.register(new ModMetadataCommandV1());
+		CommandRegistrationCallback.EVENT.register(registry -> {
+			registry.register(new ModMetadataCommandV1());
+		});
 	}
 }

--- a/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
+++ b/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
@@ -17,13 +17,10 @@
 
 package net.legacyfabric.fabric.test.command;
 
-import java.util.Objects;
-
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.ClickEventAction;
 import net.minecraft.text.LiteralText;
 
-import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 
@@ -46,10 +43,8 @@ public class ModMetadataCommand {
 		);
 	}
 
-	private static final boolean useStyle = !Objects.equals(FabricLoader.getInstance().getModContainer("minecraft").get().getMetadata().getVersion().getFriendlyString(), "1.8");
-
 	private static CommandResult execute(PermissibleCommandSource source, CommandContext ctx) throws CommandException {
-		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("mod not found")));
+		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("Couldn't find Mod container")));
 		LiteralText builder = new LiteralText("");
 		builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 		builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
@@ -59,7 +54,7 @@ public class ModMetadataCommand {
 			LiteralText issueText = new LiteralText("");
 			issueText.append("Issues: ");
 			LiteralText issueUrl = new LiteralText(contact.get("issues").get());
-			if (useStyle) issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEventAction.OPEN_URL, issueUrl.computeValue())));
+			issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEventAction.OPEN_URL, issueUrl.computeValue())));
 			issueText.append(issueUrl);
 			issueText.append("\n");
 			builder.append(issueText);
@@ -69,7 +64,7 @@ public class ModMetadataCommand {
 			LiteralText sourcesText = new LiteralText("");
 			sourcesText.append("Sources: ");
 			LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
-			if (useStyle) sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEventAction.OPEN_URL, sourcesUrl.computeValue())));
+			sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEventAction.OPEN_URL, sourcesUrl.computeValue())));
 			sourcesText.append(sourcesUrl);
 			sourcesText.append("\n");
 			builder.append(sourcesText);

--- a/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -19,6 +19,12 @@ package net.legacyfabric.fabric.test.command;
 
 import java.util.Optional;
 
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.ClickEventAction;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Style;
+import net.minecraft.util.Formatting;
+
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.command.AbstractCommand;
@@ -49,33 +55,37 @@ public class ModMetadataCommandV1 extends AbstractCommand {
 			if (optionalModContainer.isPresent()) {
 				ModContainer container = optionalModContainer.get();
 
-				StringBuilder builder = new StringBuilder();
+				LiteralText builder = new LiteralText("");
 				builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 				builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
 				ContactInformation contact = container.getMetadata().getContact();
 
 				if (contact.get("issues").isPresent()) {
-					StringBuilder issueText = new StringBuilder("");
+					LiteralText issueText = new LiteralText("");
 					issueText.append("Issues: ");
-					StringBuilder issueUrl = new StringBuilder(contact.get("issues").get());
+					LiteralText issueUrl = new LiteralText(contact.get("issues").get());
+					issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEventAction.OPEN_URL, issueUrl.computeValue())));
 					issueText.append(issueUrl);
 					issueText.append("\n");
 					builder.append(issueText);
 				}
 
 				if (contact.get("sources").isPresent()) {
-					StringBuilder sourcesText = new StringBuilder("");
+					LiteralText sourcesText = new LiteralText("");
 					sourcesText.append("Sources: ");
-					StringBuilder sourcesUrl = new StringBuilder(contact.get("sources").get());
+					LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
+					sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEventAction.OPEN_URL, sourcesUrl.computeValue())));
 					sourcesText.append(sourcesUrl);
 					sourcesText.append("\n");
 					builder.append(sourcesText);
 				}
 
 				builder.append("Metadata Type: ".concat(container.getMetadata().getType()).concat("\n"));
-				CommandV1Test.LOGGER.info(builder.toString());
+				commandSource.sendMessage(builder);
 			} else {
-				CommandV1Test.LOGGER.error("Couldn't find Mod container for mod id '" + args[0] + "'");
+				LiteralText builder = new LiteralText("Couldn't find Mod container for mod id '" + args[0] + "'");
+				builder.setStyle(new Style().setFormatting(Formatting.RED));
+				commandSource.sendMessage(builder);
 			}
 		}
 	}

--- a/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -19,18 +19,17 @@ package net.legacyfabric.fabric.test.command;
 
 import java.util.Optional;
 
-import net.minecraft.text.ClickEvent;
-import net.minecraft.text.ClickEventAction;
-import net.minecraft.text.LiteralText;
-import net.minecraft.text.Style;
-import net.minecraft.util.Formatting;
-
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.command.AbstractCommand;
 import net.minecraft.command.Command;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.CommandSource;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.ClickEventAction;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Style;
+import net.minecraft.util.Formatting;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
@@ -20,13 +20,15 @@ package net.legacyfabric.fabric.test.command;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.logger.v1.Logger;
-import net.legacyfabric.fabric.api.registry.CommandRegistry;
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
 
 public class CommandV1Test implements ModInitializer {
 	public static final Logger LOGGER = Logger.get("LegacyFabricAPI", "Test", "CommandV1Test");
 
 	@Override
 	public void onInitialize() {
-		CommandRegistry.INSTANCE.register(new ModMetadataCommandV1());
+		CommandRegistrationCallback.EVENT.register(registry -> {
+			registry.register(new ModMetadataCommandV1());
+		});
 	}
 }

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
@@ -17,12 +17,9 @@
 
 package net.legacyfabric.fabric.test.command;
 
-import java.util.Objects;
-
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.LiteralText;
 
-import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 
@@ -45,10 +42,8 @@ public class ModMetadataCommand {
 		);
 	}
 
-	private static final boolean useStyle = !Objects.equals(FabricLoader.getInstance().getModContainer("minecraft").get().getMetadata().getVersion().getFriendlyString(), "1.8");
-
 	private static CommandResult execute(PermissibleCommandSource source, CommandContext ctx) throws CommandException {
-		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("mod not found")));
+		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("Couldn't find Mod container")));
 		LiteralText builder = new LiteralText("");
 		builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 		builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
@@ -58,7 +53,7 @@ public class ModMetadataCommand {
 			LiteralText issueText = new LiteralText("");
 			issueText.append("Issues: ");
 			LiteralText issueUrl = new LiteralText(contact.get("issues").get());
-			if (useStyle) issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
+			issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
 			issueText.append(issueUrl);
 			issueText.append("\n");
 			builder.append(issueText);
@@ -68,7 +63,7 @@ public class ModMetadataCommand {
 			LiteralText sourcesText = new LiteralText("");
 			sourcesText.append("Sources: ");
 			LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
-			if (useStyle) sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
+			sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
 			sourcesText.append(sourcesUrl);
 			sourcesText.append("\n");
 			builder.append(sourcesText);

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -21,15 +21,14 @@ import java.util.Optional;
 
 import net.minecraft.command.AbstractCommand;
 import net.minecraft.command.CommandSource;
-
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.ModContainer;
-import net.fabricmc.loader.api.metadata.ContactInformation;
-
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Style;
 import net.minecraft.util.Formatting;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ContactInformation;
 
 public class ModMetadataCommandV1 extends AbstractCommand {
 	@Override

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -20,12 +20,16 @@ package net.legacyfabric.fabric.test.command;
 import java.util.Optional;
 
 import net.minecraft.command.AbstractCommand;
-import net.minecraft.command.CommandException;
 import net.minecraft.command.CommandSource;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ContactInformation;
+
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Style;
+import net.minecraft.util.Formatting;
 
 public class ModMetadataCommandV1 extends AbstractCommand {
 	@Override
@@ -39,40 +43,44 @@ public class ModMetadataCommandV1 extends AbstractCommand {
 	}
 
 	@Override
-	public void execute(CommandSource commandSource, String[] args) throws CommandException {
+	public void execute(CommandSource commandSource, String[] args) {
 		if (args.length > 0) {
 			Optional<ModContainer> optionalModContainer = FabricLoader.getInstance().getModContainer(args[0]);
 
 			if (optionalModContainer.isPresent()) {
 				ModContainer container = optionalModContainer.get();
 
-				StringBuilder builder = new StringBuilder();
+				LiteralText builder = new LiteralText("");
 				builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 				builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
 				ContactInformation contact = container.getMetadata().getContact();
 
 				if (contact.get("issues").isPresent()) {
-					StringBuilder issueText = new StringBuilder("");
+					LiteralText issueText = new LiteralText("");
 					issueText.append("Issues: ");
-					StringBuilder issueUrl = new StringBuilder(contact.get("issues").get());
+					LiteralText issueUrl = new LiteralText(contact.get("issues").get());
+					issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
 					issueText.append(issueUrl);
 					issueText.append("\n");
 					builder.append(issueText);
 				}
 
 				if (contact.get("sources").isPresent()) {
-					StringBuilder sourcesText = new StringBuilder("");
+					LiteralText sourcesText = new LiteralText("");
 					sourcesText.append("Sources: ");
-					StringBuilder sourcesUrl = new StringBuilder(contact.get("sources").get());
+					LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
+					sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
 					sourcesText.append(sourcesUrl);
 					sourcesText.append("\n");
 					builder.append(sourcesText);
 				}
 
 				builder.append("Metadata Type: ".concat(container.getMetadata().getType()).concat("\n"));
-				CommandV1Test.LOGGER.info(builder.toString());
+				commandSource.sendMessage(builder);
 			} else {
-				CommandV1Test.LOGGER.error("Couldn't find Mod container for mod id '" + args[0] + "'");
+				LiteralText builder = new LiteralText("Couldn't find Mod container for mod id '" + args[0] + "'");
+				builder.setStyle(new Style().setFormatting(Formatting.RED));
+				commandSource.sendMessage(builder);
 			}
 		}
 	}

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
@@ -20,13 +20,15 @@ package net.legacyfabric.fabric.test.command;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.logger.v1.Logger;
-import net.legacyfabric.fabric.api.registry.CommandRegistry;
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
 
 public class CommandV1Test implements ModInitializer {
 	public static final Logger LOGGER = Logger.get("LegacyFabricAPI", "Test", "CommandV1Test");
 
 	@Override
 	public void onInitialize() {
-		CommandRegistry.INSTANCE.register(new ModMetadataCommandV1());
+		CommandRegistrationCallback.EVENT.register(registry -> {
+			registry.register(new ModMetadataCommandV1());
+		});
 	}
 }

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
@@ -17,13 +17,10 @@
 
 package net.legacyfabric.fabric.test.command;
 
-import java.util.Objects;
-
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.ClickEventAction;
 import net.minecraft.text.LiteralText;
 
-import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 
@@ -46,10 +43,8 @@ public class ModMetadataCommand {
 		);
 	}
 
-	private static final boolean useStyle = !Objects.equals(FabricLoader.getInstance().getModContainer("minecraft").get().getMetadata().getVersion().getFriendlyString(), "1.8");
-
 	private static CommandResult execute(PermissibleCommandSource source, CommandContext ctx) throws CommandException {
-		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("mod not found")));
+		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("Couldn't find Mod container")));
 		LiteralText builder = new LiteralText("");
 		builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 		builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
@@ -59,7 +54,7 @@ public class ModMetadataCommand {
 			LiteralText issueText = new LiteralText("");
 			issueText.append("Issues: ");
 			LiteralText issueUrl = new LiteralText(contact.get("issues").get());
-			if (useStyle) issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEventAction.OPEN_URL, issueUrl.computeValue())));
+			issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEventAction.OPEN_URL, issueUrl.computeValue())));
 			issueText.append(issueUrl);
 			issueText.append("\n");
 			builder.append(issueText);
@@ -69,7 +64,7 @@ public class ModMetadataCommand {
 			LiteralText sourcesText = new LiteralText("");
 			sourcesText.append("Sources: ");
 			LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
-			if (useStyle) sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEventAction.OPEN_URL, sourcesUrl.computeValue())));
+			sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEventAction.OPEN_URL, sourcesUrl.computeValue())));
 			sourcesText.append(sourcesUrl);
 			sourcesText.append("\n");
 			builder.append(sourcesText);

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -19,6 +19,13 @@ package net.legacyfabric.fabric.test.command;
 
 import java.util.Optional;
 
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.ClickEventAction;
+import net.minecraft.text.LiteralText;
+
+import net.minecraft.text.Style;
+import net.minecraft.util.Formatting;
+
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.command.AbstractCommand;
@@ -48,33 +55,37 @@ public class ModMetadataCommandV1 extends AbstractCommand {
 			if (optionalModContainer.isPresent()) {
 				ModContainer container = optionalModContainer.get();
 
-				StringBuilder builder = new StringBuilder();
+				LiteralText builder = new LiteralText("");
 				builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 				builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
 				ContactInformation contact = container.getMetadata().getContact();
 
 				if (contact.get("issues").isPresent()) {
-					StringBuilder issueText = new StringBuilder("");
+					LiteralText issueText = new LiteralText("");
 					issueText.append("Issues: ");
-					StringBuilder issueUrl = new StringBuilder(contact.get("issues").get());
+					LiteralText issueUrl = new LiteralText(contact.get("issues").get());
+					issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEventAction.OPEN_URL, issueUrl.computeValue())));
 					issueText.append(issueUrl);
 					issueText.append("\n");
 					builder.append(issueText);
 				}
 
 				if (contact.get("sources").isPresent()) {
-					StringBuilder sourcesText = new StringBuilder("");
+					LiteralText sourcesText = new LiteralText("");
 					sourcesText.append("Sources: ");
-					StringBuilder sourcesUrl = new StringBuilder(contact.get("sources").get());
+					LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
+					sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEventAction.OPEN_URL, sourcesUrl.computeValue())));
 					sourcesText.append(sourcesUrl);
 					sourcesText.append("\n");
 					builder.append(sourcesText);
 				}
 
 				builder.append("Metadata Type: ".concat(container.getMetadata().getType()).concat("\n"));
-				CommandV1Test.LOGGER.info(builder.toString());
+				commandSource.sendMessage(builder);
 			} else {
-				CommandV1Test.LOGGER.error("Couldn't find Mod container for mod id '" + args[0] + "'");
+				LiteralText builder = new LiteralText("Couldn't find Mod container for mod id '" + args[0] + "'");
+				builder.setStyle(new Style().setFormatting(Formatting.RED));
+				commandSource.sendMessage(builder);
 			}
 		}
 	}

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -19,18 +19,16 @@ package net.legacyfabric.fabric.test.command;
 
 import java.util.Optional;
 
-import net.minecraft.text.ClickEvent;
-import net.minecraft.text.ClickEventAction;
-import net.minecraft.text.LiteralText;
-
-import net.minecraft.text.Style;
-import net.minecraft.util.Formatting;
-
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.command.AbstractCommand;
 import net.minecraft.command.Command;
 import net.minecraft.command.CommandSource;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.ClickEventAction;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Style;
+import net.minecraft.util.Formatting;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/command/CommandV1Test.java
@@ -20,13 +20,15 @@ package net.legacyfabric.fabric.test.command;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.logger.v1.Logger;
-import net.legacyfabric.fabric.api.registry.CommandRegistry;
+import net.legacyfabric.fabric.api.registry.CommandRegistrationCallback;
 
 public class CommandV1Test implements ModInitializer {
 	public static final Logger LOGGER = Logger.get("LegacyFabricAPI", "Test", "CommandV1Test");
 
 	@Override
 	public void onInitialize() {
-		CommandRegistry.INSTANCE.register(new ModMetadataCommandV1());
+		CommandRegistrationCallback.EVENT.register(registry -> {
+			registry.register(new ModMetadataCommandV1());
+		});
 	}
 }

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommand.java
@@ -17,12 +17,9 @@
 
 package net.legacyfabric.fabric.test.command;
 
-import java.util.Objects;
-
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.LiteralText;
 
-import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ContactInformation;
 
@@ -45,10 +42,8 @@ public class ModMetadataCommand {
 		);
 	}
 
-	private static final boolean useStyle = !Objects.equals(FabricLoader.getInstance().getModContainer("minecraft").get().getMetadata().getVersion().getFriendlyString(), "1.8");
-
 	private static CommandResult execute(PermissibleCommandSource source, CommandContext ctx) throws CommandException {
-		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("mod not found")));
+		ModContainer container = ctx.<ModContainer>getOne("modid").orElseThrow(() -> new CommandException(new LiteralText("Couldn't find Mod container")));
 		LiteralText builder = new LiteralText("");
 		builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 		builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
@@ -58,7 +53,7 @@ public class ModMetadataCommand {
 			LiteralText issueText = new LiteralText("");
 			issueText.append("Issues: ");
 			LiteralText issueUrl = new LiteralText(contact.get("issues").get());
-			if (useStyle) issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
+			issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
 			issueText.append(issueUrl);
 			issueText.append("\n");
 			builder.append(issueText);
@@ -68,7 +63,7 @@ public class ModMetadataCommand {
 			LiteralText sourcesText = new LiteralText("");
 			sourcesText.append("Sources: ");
 			LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
-			if (useStyle) sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
+			sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
 			sourcesText.append(sourcesUrl);
 			sourcesText.append("\n");
 			builder.append(sourcesText);

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -22,15 +22,14 @@ import java.util.Optional;
 import net.minecraft.command.AbstractCommand;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.MinecraftServer;
-
-import net.fabricmc.loader.api.FabricLoader;
-import net.fabricmc.loader.api.ModContainer;
-import net.fabricmc.loader.api.metadata.ContactInformation;
-
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Style;
 import net.minecraft.util.Formatting;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.loader.api.ModContainer;
+import net.fabricmc.loader.api.metadata.ContactInformation;
 
 public class ModMetadataCommandV1 extends AbstractCommand {
 	@Override

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/command/ModMetadataCommandV1.java
@@ -20,13 +20,17 @@ package net.legacyfabric.fabric.test.command;
 import java.util.Optional;
 
 import net.minecraft.command.AbstractCommand;
-import net.minecraft.command.CommandException;
 import net.minecraft.command.CommandSource;
 import net.minecraft.server.MinecraftServer;
 
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ContactInformation;
+
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Style;
+import net.minecraft.util.Formatting;
 
 public class ModMetadataCommandV1 extends AbstractCommand {
 	@Override
@@ -40,40 +44,44 @@ public class ModMetadataCommandV1 extends AbstractCommand {
 	}
 
 	@Override
-	public void method_3279(MinecraftServer minecraftServer, CommandSource commandSource, String[] args) throws CommandException {
+	public void method_3279(MinecraftServer minecraftServer, CommandSource commandSource, String[] args) {
 		if (args.length > 0) {
 			Optional<ModContainer> optionalModContainer = FabricLoader.getInstance().getModContainer(args[0]);
 
 			if (optionalModContainer.isPresent()) {
 				ModContainer container = optionalModContainer.get();
 
-				StringBuilder builder = new StringBuilder();
+				LiteralText builder = new LiteralText("");
 				builder.append("Mod Name: ".concat(container.getMetadata().getName()).concat("\n"));
 				builder.append("Description: ".concat(container.getMetadata().getDescription()).concat("\n"));
 				ContactInformation contact = container.getMetadata().getContact();
 
 				if (contact.get("issues").isPresent()) {
-					StringBuilder issueText = new StringBuilder("");
+					LiteralText issueText = new LiteralText("");
 					issueText.append("Issues: ");
-					StringBuilder issueUrl = new StringBuilder(contact.get("issues").get());
+					LiteralText issueUrl = new LiteralText(contact.get("issues").get());
+					issueUrl.setStyle(issueText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, issueUrl.computeValue())));
 					issueText.append(issueUrl);
 					issueText.append("\n");
 					builder.append(issueText);
 				}
 
 				if (contact.get("sources").isPresent()) {
-					StringBuilder sourcesText = new StringBuilder("");
+					LiteralText sourcesText = new LiteralText("");
 					sourcesText.append("Sources: ");
-					StringBuilder sourcesUrl = new StringBuilder(contact.get("sources").get());
+					LiteralText sourcesUrl = new LiteralText(contact.get("sources").get());
+					sourcesUrl.setStyle(sourcesText.getStyle().setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, sourcesUrl.computeValue())));
 					sourcesText.append(sourcesUrl);
 					sourcesText.append("\n");
 					builder.append(sourcesText);
 				}
 
 				builder.append("Metadata Type: ".concat(container.getMetadata().getType()).concat("\n"));
-				CommandV1Test.LOGGER.info(builder.toString());
+				commandSource.sendMessage(builder);
 			} else {
-				CommandV1Test.LOGGER.error("Couldn't find Mod container for mod id '" + args[0] + "'");
+				LiteralText builder = new LiteralText("Couldn't find Mod container for mod id '" + args[0] + "'");
+				builder.setStyle(new Style().setFormatting(Formatting.RED));
+				commandSource.sendMessage(builder);
 			}
 		}
 	}


### PR DESCRIPTION
## The Problem

As it currently stands, trying to register sponge commands through [`CommandRegistrar#EVENT`](https://github.com/Legacy-Fabric/fabric/blob/main/legacy-fabric-command-api-v2/1.8.9/src/main/java/net/legacyfabric/fabric/api/command/v2/CommandRegistrar.java) from either a `ClientModInitializer` or a `DedicatedServerModInitializer` results in non-determinism as whether they are successfully registered depends on the order the initializers were invoked by fabric loader (because `CommandRegistrar#EVENT` is also invoked from these entrypoints).

## The Solution

I added a [`CommandRegistrationCallback#EVENT`](https://github.com/AstraeaDevelopment/fabric/blob/defer-sponge-command-registration/legacy-fabric-command-api-v1/common/src/main/java/net/legacyfabric/fabric/api/registry/CommandRegistrationCallback.java) event in the command api v1 library that is invoked before the vanilla command manager is filled with mod commands during the [`ServerLifecycleEvents#SERVER_STARTING`](https://github.com/AstraeaDevelopment/fabric/blob/defer-sponge-command-registration/legacy-fabric-command-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/command/CommandInitializer.java#L33) callback. I then wrapped the sponge command registration event invocations in the [`ImplInit`](https://github.com/AstraeaDevelopment/fabric/blob/defer-sponge-command-registration/legacy-fabric-command-api-v2/1.8.9/src/main/java/net/legacyfabric/fabric/impl/command/ImplInit.java#L29) classes so that their registration is now deferred to the `ServerLifecycleEvents#SERVER_STARTING` callback rather than the mod initializers.

This pull request ensures a strict load order between sponge commands and vanilla commands without breaking backwards compatibility.