### PR TITLE
Registry sync v2 - Entity

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,4 @@ legacy-fabric-block-entity-api-v1.version = 1.0.0
 legacy-fabric-rendering-api-v1.version = 1.0.0
 legacy-fabric-resource-loader-v1.version = 2.2.2
 legacy-fabric-effect-api-v1.version = 1.0.0
+legacy-fabric-entity-api-v1.version = 1.0.0

--- a/legacy-fabric-entity-api-v1/1.10.2/gradle.properties
+++ b/legacy-fabric-entity-api-v1/1.10.2/gradle.properties
@@ -1,0 +1,2 @@
+minVersionIncluded=1.9
+maxVersionIncluded=1.10.2

--- a/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
+++ b/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.api.entity;
 
 import net.legacyfabric.fabric.api.util.Identifier;

--- a/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
+++ b/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
@@ -1,0 +1,10 @@
+package net.legacyfabric.fabric.api.entity;
+
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.impl.entity.versionned.EntityHelperImpl;
+
+public interface EntityHelper {
+	static void registerSpawnEgg(Identifier identifier, int color0, int color1) {
+		EntityHelperImpl.registerSpawnEgg(identifier, color0, color1);
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
+++ b/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
@@ -1,13 +1,30 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.entity.versionned;
+
+import net.minecraft.entity.Entity;
 
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
-
-import net.minecraft.entity.Entity;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
 
 public class EarlyInitializer implements PreLaunchEntrypoint {
 	@Override
@@ -15,7 +32,7 @@ public class EarlyInitializer implements PreLaunchEntrypoint {
 		RegistryInitializedEvent.event(RegistryIds.ENTITY_TYPES).register(EarlyInitializer::entityRegistryInit);
 	}
 
-	private static void entityRegistryInit(Registry<?> holder) {
-		SyncedRegistry<Class<? extends Entity>> registry = (SyncedRegistry<Class<? extends Entity>>) holder;
+	private static void entityRegistryInit(FabricRegistry<?> holder) {
+		SyncedFabricRegistry<Class<? extends Entity>> registry = (SyncedFabricRegistry<Class<? extends Entity>>) holder;
 	}
 }

--- a/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
+++ b/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
@@ -1,0 +1,21 @@
+package net.legacyfabric.fabric.impl.entity.versionned;
+
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
+
+import net.minecraft.entity.Entity;
+
+public class EarlyInitializer implements PreLaunchEntrypoint {
+	@Override
+	public void onPreLaunch() {
+		RegistryInitializedEvent.event(RegistryIds.ENTITY_TYPES).register(EarlyInitializer::entityRegistryInit);
+	}
+
+	private static void entityRegistryInit(Registry<?> holder) {
+		SyncedRegistry<Class<? extends Entity>> registry = (SyncedRegistry<Class<? extends Entity>>) holder;
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
+++ b/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
@@ -1,0 +1,12 @@
+package net.legacyfabric.fabric.impl.entity.versionned;
+
+import net.legacyfabric.fabric.api.util.Identifier;
+
+import net.minecraft.entity.EntityType;
+
+public class EntityHelperImpl {
+	public static void registerSpawnEgg(Identifier identifier, int color0, int color1) {
+		String mcId = identifier.toTranslationKey();
+		EntityType.SPAWN_EGGS.put(mcId, new EntityType.SpawnEggData(mcId, color0, color1));
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
+++ b/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
@@ -1,8 +1,25 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.entity.versionned;
 
-import net.legacyfabric.fabric.api.util.Identifier;
-
 import net.minecraft.entity.EntityType;
+
+import net.legacyfabric.fabric.api.util.Identifier;
 
 public class EntityHelperImpl {
 	public static void registerSpawnEgg(Identifier identifier, int color0, int color1) {

--- a/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
+++ b/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
@@ -1,17 +1,23 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.mixin.entity;
 
-import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-
-import net.legacyfabric.fabric.api.util.Identifier;
-import net.legacyfabric.fabric.impl.entity.EntityHelperImpl;
-import net.legacyfabric.fabric.impl.entity.MapEntityRegistryWrapper;
-
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
+import java.util.Map;
 
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -22,7 +28,14 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Map;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.impl.entity.MapEntityRegistryWrapper;
 
 @Mixin(EntityType.class)
 public class EntityTypeMixin {
@@ -43,7 +56,7 @@ public class EntityTypeMixin {
 	private static Map<String, Integer> NAME_ID_MAP;
 
 	@Unique
-	private static Registry<Class<? extends Entity>> ENTITY_TYPE_REGISTRY;
+	private static FabricRegistry<Class<? extends Entity>> ENTITY_TYPE_REGISTRY;
 
 	@Inject(method = "load", at = @At("RETURN"))
 	private static void registerRegistry(CallbackInfo ci) {

--- a/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
+++ b/legacy-fabric-entity-api-v1/1.10.2/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
@@ -1,0 +1,77 @@
+package net.legacyfabric.fabric.mixin.entity;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.impl.entity.EntityHelperImpl;
+import net.legacyfabric.fabric.impl.entity.MapEntityRegistryWrapper;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Map;
+
+@Mixin(EntityType.class)
+public class EntityTypeMixin {
+	@Shadow
+	@Final
+	private static Map<String, Class<? extends Entity>> NAME_CLASS_MAP;
+	@Shadow
+	@Final
+	private static Map<Class<? extends Entity>, String> CLASS_NAME_MAP;
+	@Shadow
+	@Final
+	private static Map<Integer, Class<? extends Entity>> ID_CLASS_MAP;
+	@Shadow
+	@Final
+	private static Map<Class<? extends Entity>, Integer> CLASS_ID_MAP;
+	@Shadow
+	@Final
+	private static Map<String, Integer> NAME_ID_MAP;
+
+	@Unique
+	private static Registry<Class<? extends Entity>> ENTITY_TYPE_REGISTRY;
+
+	@Inject(method = "load", at = @At("RETURN"))
+	private static void registerRegistry(CallbackInfo ci) {
+		ENTITY_TYPE_REGISTRY = new MapEntityRegistryWrapper<>(
+				NAME_CLASS_MAP,
+				CLASS_NAME_MAP,
+				ID_CLASS_MAP,
+				CLASS_ID_MAP,
+				NAME_ID_MAP
+		);
+
+		RegistryHelper.addRegistry(RegistryIds.ENTITY_TYPES, ENTITY_TYPE_REGISTRY);
+	}
+
+	@ModifyArg(method = {"createInstanceFromName", "createInstanceFromNbt", "getIdByName"},
+			at = @At(value = "INVOKE", target = "Ljava/util/Map;get(Ljava/lang/Object;)Ljava/lang/Object;", remap = false))
+	private static Object fixOldRegistryNames(Object o) {
+		String key = (String) o;
+
+		if (key.contains(":")) {
+			Identifier identifier = new Identifier(key);
+			Class<? extends Entity> clazz = RegistryHelper.getValue(RegistryIds.ENTITY_TYPES, identifier);
+
+			if (clazz != null) {
+				key = CLASS_NAME_MAP.get(clazz);
+			}
+		}
+
+		return key;
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.10.2/src/main/resources/fabric.mod.json
+++ b/legacy-fabric-entity-api-v1/1.10.2/src/main/resources/fabric.mod.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "id": "legacy-fabric-entity-api-v1",
+  "name": "Legacy Fabric Entity API (V1)",
+  "version": "${version}",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "icon": "assets/legacy-fabric/icon.png",
+  "contact": {
+    "homepage": "https://legacyfabric.net/",
+    "irc": "irc://irc.esper.net:6667/legacyfabric",
+    "issues": "https://github.com/Legacy-Fabric/fabric/issues",
+    "sources": "https://github.com/Legacy-Fabric/fabric"
+  },
+  "authors": [
+    "Legacy-Fabric"
+  ],
+  "depends": {
+    "fabricloader": ">=0.4.0",
+    "minecraft": "${minecraft_version}"
+  },
+  "description": "Entity utils",
+  "entrypoints": {
+    "preLaunch": [
+      "net.legacyfabric.fabric.impl.entity.versionned.EarlyInitializer"
+    ]
+  },
+  "mixins": [
+    "legacy-fabric-entity-api-v1.mixins.json"
+  ],
+  "custom": {
+    "loom:injected_interfaces": {
+    },
+    "modmenu": {
+      "badges": [ "library" ],
+      "parent": {
+        "id": "legacy-fabric-api",
+        "name": "Legacy Fabric API",
+        "badges": [ "library" ],
+        "description": "Core API module providing key hooks and inter-compatibility features for Minecraft 1.7.10-1.12.2.",
+        "icon": "assets/legacy-fabric/icon.png"
+      }
+    }
+  }
+}

--- a/legacy-fabric-entity-api-v1/1.10.2/src/main/resources/legacy-fabric-entity-api-v1.mixins.json
+++ b/legacy-fabric-entity-api-v1/1.10.2/src/main/resources/legacy-fabric-entity-api-v1.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "package": "net.legacyfabric.fabric.mixin.entity",
+  "compatibilityLevel": "JAVA_8",
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "mixins": [
+    "EntityTypeMixin"
+  ],
+  "client": [
+  ]
+}

--- a/legacy-fabric-entity-api-v1/1.12.2/gradle.properties
+++ b/legacy-fabric-entity-api-v1/1.12.2/gradle.properties
@@ -1,0 +1,2 @@
+minVersionIncluded=1.11
+maxVersionIncluded=1.12.2

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.api.entity;
 
 import net.legacyfabric.fabric.api.util.Identifier;

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
@@ -1,0 +1,10 @@
+package net.legacyfabric.fabric.api.entity;
+
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.impl.entity.EntityHelperImpl;
+
+public interface EntityHelper {
+	static void registerSpawnEgg(Identifier identifier, int color0, int color1) {
+		EntityHelperImpl.registerSpawnEgg(identifier, color0, color1);
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
@@ -1,7 +1,7 @@
 package net.legacyfabric.fabric.api.entity;
 
 import net.legacyfabric.fabric.api.util.Identifier;
-import net.legacyfabric.fabric.impl.entity.EntityHelperImpl;
+import net.legacyfabric.fabric.impl.entity.versionned.EntityHelperImpl;
 
 public interface EntityHelper {
 	static void registerSpawnEgg(Identifier identifier, int color0, int color1) {

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/entity/EarlyInitializer.java
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/entity/EarlyInitializer.java
@@ -1,0 +1,62 @@
+package net.legacyfabric.fabric.impl.entity;
+
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
+
+import net.legacyfabric.fabric.mixin.entity.EntityTypeAccessor;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.util.Identifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EarlyInitializer implements PreLaunchEntrypoint {
+	@Override
+	public void onPreLaunch() {
+		RegistryInitializedEvent.event(RegistryIds.ENTITY_TYPES).register(EarlyInitializer::entityRegistryInit);
+	}
+
+	private static void entityRegistryInit(Registry<?> holder) {
+		SyncedRegistry<Class<? extends Entity>> registry = (SyncedRegistry<Class<? extends Entity>>) holder;
+
+		registry.fabric$getEntryAddedCallback().register((rawId, id, object) -> {
+			EntityType.IDENTIFIERS.add(new Identifier(id.toString()));
+
+			while (rawId >= EntityTypeAccessor.getNAMES().size()) {
+				EntityTypeAccessor.getNAMES().add(null);
+			}
+
+			EntityTypeAccessor.getNAMES().set(rawId, id.toTranslationKey());
+		});
+
+		registry.fabric$getRegistryRemapCallback().register(changedIdsMap -> {
+			List<String> oldList = EntityTypeAccessor.getNAMES();
+			List<String> newList = new ArrayList<>();
+
+			for (int i = 0; i < oldList.size(); i++) {
+				int id = i;
+				String name = oldList.get(i);
+
+				if (name == null) continue;
+
+				if (changedIdsMap.containsKey(id)) {
+					id = changedIdsMap.get(id).getId();
+				}
+
+				while (id >= newList.size()) {
+					newList.add(null);
+				}
+
+				newList.set(id, name);
+			}
+
+			EntityTypeAccessor.setNAMES(newList);
+		});
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/entity/EntityHelperImpl.java
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/entity/EntityHelperImpl.java
@@ -1,0 +1,12 @@
+package net.legacyfabric.fabric.impl.entity;
+
+import net.legacyfabric.fabric.api.util.Identifier;
+
+import net.minecraft.entity.EntityType;
+
+public class EntityHelperImpl {
+	public static void registerSpawnEgg(Identifier identifier, int color0, int color1) {
+		net.minecraft.util.Identifier mcId = new net.minecraft.util.Identifier(identifier.toString());
+		EntityType.SPAWN_EGGS.put(mcId, new EntityType.SpawnEggData(mcId, color0, color1));
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
@@ -1,20 +1,36 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.entity.versionned;
 
-import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
-
-import net.legacyfabric.fabric.mixin.entity.EntityTypeAccessor;
+import java.util.ArrayList;
+import java.util.List;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.util.Identifier;
 
-import java.util.ArrayList;
-import java.util.List;
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
+import net.legacyfabric.fabric.mixin.entity.EntityTypeAccessor;
 
 public class EarlyInitializer implements PreLaunchEntrypoint {
 	@Override
@@ -22,21 +38,21 @@ public class EarlyInitializer implements PreLaunchEntrypoint {
 		RegistryInitializedEvent.event(RegistryIds.ENTITY_TYPES).register(EarlyInitializer::entityRegistryInit);
 	}
 
-	private static void entityRegistryInit(Registry<?> holder) {
-		SyncedRegistry<Class<? extends Entity>> registry = (SyncedRegistry<Class<? extends Entity>>) holder;
+	private static void entityRegistryInit(FabricRegistry<?> holder) {
+		SyncedFabricRegistry<Class<? extends Entity>> registry = (SyncedFabricRegistry<Class<? extends Entity>>) holder;
 
 		registry.fabric$getEntryAddedCallback().register((rawId, id, object) -> {
 			EntityType.IDENTIFIERS.add(new Identifier(id.toString()));
 
-			while (rawId >= EntityTypeAccessor.getNAMES().size()) {
-				EntityTypeAccessor.getNAMES().add(null);
+			while (rawId >= EntityTypeAccessor.getEntityNameList().size()) {
+				EntityTypeAccessor.getEntityNameList().add(null);
 			}
 
-			EntityTypeAccessor.getNAMES().set(rawId, id.toTranslationKey());
+			EntityTypeAccessor.getEntityNameList().set(rawId, id.toTranslationKey());
 		});
 
 		registry.fabric$getRegistryRemapCallback().register(changedIdsMap -> {
-			List<String> oldList = EntityTypeAccessor.getNAMES();
+			List<String> oldList = EntityTypeAccessor.getEntityNameList();
 			List<String> newList = new ArrayList<>();
 
 			for (int i = 0; i < oldList.size(); i++) {
@@ -56,7 +72,7 @@ public class EarlyInitializer implements PreLaunchEntrypoint {
 				newList.set(id, name);
 			}
 
-			EntityTypeAccessor.setNAMES(newList);
+			EntityTypeAccessor.setEntityNameList(newList);
 		});
 	}
 }

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
@@ -1,4 +1,4 @@
-package net.legacyfabric.fabric.impl.entity;
+package net.legacyfabric.fabric.impl.entity.versionned;
 
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
@@ -1,4 +1,4 @@
-package net.legacyfabric.fabric.impl.entity;
+package net.legacyfabric.fabric.impl.entity.versionned;
 
 import net.legacyfabric.fabric.api.util.Identifier;
 

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
@@ -1,8 +1,25 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.entity.versionned;
 
-import net.legacyfabric.fabric.api.util.Identifier;
-
 import net.minecraft.entity.EntityType;
+
+import net.legacyfabric.fabric.api.util.Identifier;
 
 public class EntityHelperImpl {
 	public static void registerSpawnEgg(Identifier identifier, int color0, int color1) {

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeAccessor.java
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeAccessor.java
@@ -1,21 +1,37 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.mixin.entity;
 
-import net.minecraft.entity.EntityType;
+import java.util.List;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
-import java.util.List;
+import net.minecraft.entity.EntityType;
 
 @Mixin(EntityType.class)
 public interface EntityTypeAccessor {
-	@Accessor
-	static List<String> getNAMES() {
+	@Accessor("NAMES")
+	static List<String> getEntityNameList() {
 		return null;
 	}
 
-	@Accessor
-	static void setNAMES(List<String> names) {
-
+	@Accessor("NAMES")
+	static void setEntityNameList(List<String> names) {
 	}
 }

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeAccessor.java
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeAccessor.java
@@ -1,0 +1,21 @@
+package net.legacyfabric.fabric.mixin.entity;
+
+import net.minecraft.entity.EntityType;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+
+@Mixin(EntityType.class)
+public interface EntityTypeAccessor {
+	@Accessor
+	static List<String> getNAMES() {
+		return null;
+	}
+
+	@Accessor
+	static void setNAMES(List<String> names) {
+
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
@@ -1,0 +1,30 @@
+package net.legacyfabric.fabric.mixin.entity;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.SimpleRegistry;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EntityType.class)
+public class EntityTypeMixin {
+	@Shadow
+	@Final
+	public static SimpleRegistry<Identifier, Class<? extends Entity>> REGISTRY;
+
+	@Inject(method = "load", at = @At("RETURN"))
+	private static void registerRegistry(CallbackInfo ci) {
+		RegistryHelper.addRegistry(RegistryIds.ENTITY_TYPES, REGISTRY);
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
@@ -1,14 +1,21 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.mixin.entity;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
-
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.SimpleRegistry;
 
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -16,6 +23,14 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.SimpleRegistry;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 
 @Mixin(EntityType.class)
 public class EntityTypeMixin {

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/resources/fabric.mod.json
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/resources/fabric.mod.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "id": "legacy-fabric-entity-api-v1",
+  "name": "Legacy Fabric Entity API (V1)",
+  "version": "${version}",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "icon": "assets/legacy-fabric/icon.png",
+  "contact": {
+    "homepage": "https://legacyfabric.net/",
+    "irc": "irc://irc.esper.net:6667/legacyfabric",
+    "issues": "https://github.com/Legacy-Fabric/fabric/issues",
+    "sources": "https://github.com/Legacy-Fabric/fabric"
+  },
+  "authors": [
+    "Legacy-Fabric"
+  ],
+  "depends": {
+    "fabricloader": ">=0.4.0",
+    "minecraft": "${minecraft_version}"
+  },
+  "description": "Entity utils",
+  "entrypoints": {
+    "preLaunch": [
+      "net.legacyfabric.fabric.impl.entity.EarlyInitializer"
+    ]
+  },
+  "mixins": [
+    "legacy-fabric-entity-api-v1.mixins.json"
+  ],
+  "custom": {
+    "loom:injected_interfaces": {
+    },
+    "modmenu": {
+      "badges": [ "library" ],
+      "parent": {
+        "id": "legacy-fabric-api",
+        "name": "Legacy Fabric API",
+        "badges": [ "library" ],
+        "description": "Core API module providing key hooks and inter-compatibility features for Minecraft 1.7.10-1.12.2.",
+        "icon": "assets/legacy-fabric/icon.png"
+      }
+    }
+  }
+}

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/resources/fabric.mod.json
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
   "description": "Entity utils",
   "entrypoints": {
     "preLaunch": [
-      "net.legacyfabric.fabric.impl.entity.EarlyInitializer"
+      "net.legacyfabric.fabric.impl.entity.versionned.EarlyInitializer"
     ]
   },
   "mixins": [

--- a/legacy-fabric-entity-api-v1/1.12.2/src/main/resources/legacy-fabric-entity-api-v1.mixins.json
+++ b/legacy-fabric-entity-api-v1/1.12.2/src/main/resources/legacy-fabric-entity-api-v1.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "net.legacyfabric.fabric.mixin.entity",
+  "compatibilityLevel": "JAVA_8",
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "mixins": [
+    "EntityTypeAccessor",
+    "EntityTypeMixin"
+  ],
+  "client": [
+  ]
+}

--- a/legacy-fabric-entity-api-v1/1.7.10/gradle.properties
+++ b/legacy-fabric-entity-api-v1/1.7.10/gradle.properties
@@ -1,0 +1,2 @@
+minVersionIncluded=1.7.10
+maxVersionIncluded=1.7.10

--- a/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
+++ b/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.api.entity;
 
 import net.legacyfabric.fabric.api.util.Identifier;

--- a/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
+++ b/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
@@ -1,0 +1,10 @@
+package net.legacyfabric.fabric.api.entity;
+
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.impl.entity.versionned.EntityHelperImpl;
+
+public interface EntityHelper {
+	static void registerSpawnEgg(Identifier identifier, int color0, int color1) {
+		EntityHelperImpl.registerSpawnEgg(identifier, color0, color1);
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
+++ b/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
@@ -1,0 +1,49 @@
+package net.legacyfabric.fabric.impl.entity.versionned;
+
+import com.google.common.collect.Maps;
+
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
+
+import net.legacyfabric.fabric.mixin.entity.SpawnEggDataAccessor;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.class_868;
+
+import java.util.Map;
+
+public class EarlyInitializer implements PreLaunchEntrypoint {
+	@Override
+	public void onPreLaunch() {
+		RegistryInitializedEvent.event(RegistryIds.ENTITY_TYPES).register(EarlyInitializer::entityRegistryInit);
+	}
+
+	private static void entityRegistryInit(Registry<?> holder) {
+		SyncedRegistry<Class<? extends Entity>> registry = (SyncedRegistry<Class<? extends Entity>>) holder;
+
+		registry.fabric$getRegistryRemapCallback().register(changedIdsMap -> {
+			Map<Integer, class_868> newMap = Maps.newLinkedHashMap();
+
+			for (Object entry1 : EntityType.field_3267.entrySet()) {
+				Map.Entry<Object, Object> entry = (Map.Entry) entry1;
+				int id = (int) entry.getKey();
+				class_868 spawnEggData = (class_868) entry.getValue();
+
+				if (changedIdsMap.containsKey(id)) {
+					id = changedIdsMap.get(id).getId();
+					((SpawnEggDataAccessor) spawnEggData).setField_3273(id);
+				}
+
+				newMap.put(id, spawnEggData);
+			}
+
+			EntityType.field_3267.clear();
+			EntityType.field_3267.putAll(newMap);
+		});
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
+++ b/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
@@ -1,21 +1,37 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.entity.versionned;
 
+import java.util.Map;
+
 import com.google.common.collect.Maps;
-
-import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
-
-import net.legacyfabric.fabric.mixin.entity.SpawnEggDataAccessor;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.class_868;
 
-import java.util.Map;
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
+import net.legacyfabric.fabric.mixin.entity.SpawnEggDataAccessor;
 
 public class EarlyInitializer implements PreLaunchEntrypoint {
 	@Override
@@ -23,8 +39,8 @@ public class EarlyInitializer implements PreLaunchEntrypoint {
 		RegistryInitializedEvent.event(RegistryIds.ENTITY_TYPES).register(EarlyInitializer::entityRegistryInit);
 	}
 
-	private static void entityRegistryInit(Registry<?> holder) {
-		SyncedRegistry<Class<? extends Entity>> registry = (SyncedRegistry<Class<? extends Entity>>) holder;
+	private static void entityRegistryInit(FabricRegistry<?> holder) {
+		SyncedFabricRegistry<Class<? extends Entity>> registry = (SyncedFabricRegistry<Class<? extends Entity>>) holder;
 
 		registry.fabric$getRegistryRemapCallback().register(changedIdsMap -> {
 			Map<Integer, class_868> newMap = Maps.newLinkedHashMap();
@@ -36,7 +52,7 @@ public class EarlyInitializer implements PreLaunchEntrypoint {
 
 				if (changedIdsMap.containsKey(id)) {
 					id = changedIdsMap.get(id).getId();
-					((SpawnEggDataAccessor) spawnEggData).setField_3273(id);
+					((SpawnEggDataAccessor) spawnEggData).setId(id);
 				}
 
 				newMap.put(id, spawnEggData);

--- a/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
+++ b/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
@@ -1,0 +1,16 @@
+package net.legacyfabric.fabric.impl.entity.versionned;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.util.Identifier;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.class_868;
+
+public class EntityHelperImpl {
+	public static void registerSpawnEgg(Identifier identifier, int color0, int color1) {
+		int mcId = RegistryHelper.getRawId(RegistryIds.ENTITY_TYPES,
+				RegistryHelper.getValue(RegistryIds.ENTITY_TYPES, identifier));
+		EntityType.field_3267.put(mcId, new class_868(mcId, color0, color1));
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
+++ b/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
@@ -1,11 +1,28 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.entity.versionned;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.class_868;
 
 import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.util.Identifier;
-
-import net.minecraft.entity.EntityType;
-import net.minecraft.entity.class_868;
 
 public class EntityHelperImpl {
 	public static void registerSpawnEgg(Identifier identifier, int color0, int color1) {

--- a/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
+++ b/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
@@ -1,0 +1,70 @@
+package net.legacyfabric.fabric.mixin.entity;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.impl.entity.MapEntityRegistryWrapper;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Map;
+
+@Mixin(EntityType.class)
+public class EntityTypeMixin {
+	@Shadow
+	private static Map<String, Class<? extends Entity>> NAME_CLASS_MAP;
+	@Shadow
+	private static Map<Class<? extends Entity>, String> CLASS_NAME_MAP;
+	@Shadow
+	private static Map<Integer, Class<? extends Entity>> ID_CLASS_MAP;
+	@Shadow
+	private static Map<Class<? extends Entity>, Integer> CLASS_ID_MAP;
+	@Shadow
+	private static Map<String, Integer> field_3272;
+
+	@Unique
+	private static Registry<Class<? extends Entity>> ENTITY_TYPE_REGISTRY;
+
+	@Inject(method = "load", at = @At("RETURN"))
+	private static void registerRegistry(CallbackInfo ci) {
+		ENTITY_TYPE_REGISTRY = new MapEntityRegistryWrapper<>(
+				NAME_CLASS_MAP,
+				CLASS_NAME_MAP,
+				ID_CLASS_MAP,
+				CLASS_ID_MAP,
+				field_3272
+		);
+
+		RegistryHelper.addRegistry(RegistryIds.ENTITY_TYPES, ENTITY_TYPE_REGISTRY);
+	}
+
+	@ModifyArg(method = {"createInstanceFromName", "createInstanceFromNbt"},
+			at = @At(value = "INVOKE", target = "Ljava/util/Map;get(Ljava/lang/Object;)Ljava/lang/Object;", remap = false))
+	private static Object fixOldRegistryNames(Object o) {
+		String key = (String) o;
+
+		if (key.contains(":")) {
+			Identifier identifier = new Identifier(key);
+			Class<? extends Entity> clazz = RegistryHelper.getValue(RegistryIds.ENTITY_TYPES, identifier);
+
+			if (clazz != null) {
+				key = CLASS_NAME_MAP.get(clazz);
+			}
+		}
+
+		return key;
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
+++ b/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
@@ -1,16 +1,23 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.mixin.entity;
 
-import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-
-import net.legacyfabric.fabric.api.util.Identifier;
-import net.legacyfabric.fabric.impl.entity.MapEntityRegistryWrapper;
-
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
+import java.util.Map;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -20,7 +27,14 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Map;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.impl.entity.MapEntityRegistryWrapper;
 
 @Mixin(EntityType.class)
 public class EntityTypeMixin {
@@ -36,7 +50,7 @@ public class EntityTypeMixin {
 	private static Map<String, Integer> field_3272;
 
 	@Unique
-	private static Registry<Class<? extends Entity>> ENTITY_TYPE_REGISTRY;
+	private static FabricRegistry<Class<? extends Entity>> ENTITY_TYPE_REGISTRY;
 
 	@Inject(method = "load", at = @At("RETURN"))
 	private static void registerRegistry(CallbackInfo ci) {

--- a/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/entity/SpawnEggDataAccessor.java
+++ b/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/entity/SpawnEggDataAccessor.java
@@ -1,12 +1,29 @@
-package net.legacyfabric.fabric.mixin.entity;
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import net.minecraft.entity.class_868;
+package net.legacyfabric.fabric.mixin.entity;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
+import net.minecraft.entity.class_868;
+
 @Mixin(class_868.class)
 public interface SpawnEggDataAccessor {
-	@Accessor
-	void setField_3273(int id);
+	@Accessor("field_3273")
+	void setId(int id);
 }

--- a/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/entity/SpawnEggDataAccessor.java
+++ b/legacy-fabric-entity-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/entity/SpawnEggDataAccessor.java
@@ -1,0 +1,12 @@
+package net.legacyfabric.fabric.mixin.entity;
+
+import net.minecraft.entity.class_868;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(class_868.class)
+public interface SpawnEggDataAccessor {
+	@Accessor
+	void setField_3273(int id);
+}

--- a/legacy-fabric-entity-api-v1/1.7.10/src/main/resources/fabric.mod.json
+++ b/legacy-fabric-entity-api-v1/1.7.10/src/main/resources/fabric.mod.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "id": "legacy-fabric-entity-api-v1",
+  "name": "Legacy Fabric Entity API (V1)",
+  "version": "${version}",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "icon": "assets/legacy-fabric/icon.png",
+  "contact": {
+    "homepage": "https://legacyfabric.net/",
+    "irc": "irc://irc.esper.net:6667/legacyfabric",
+    "issues": "https://github.com/Legacy-Fabric/fabric/issues",
+    "sources": "https://github.com/Legacy-Fabric/fabric"
+  },
+  "authors": [
+    "Legacy-Fabric"
+  ],
+  "depends": {
+    "fabricloader": ">=0.4.0",
+    "minecraft": "${minecraft_version}"
+  },
+  "description": "Entity utils",
+  "entrypoints": {
+    "preLaunch": [
+      "net.legacyfabric.fabric.impl.entity.versionned.EarlyInitializer"
+    ]
+  },
+  "mixins": [
+    "legacy-fabric-entity-api-v1.mixins.json"
+  ],
+  "custom": {
+    "loom:injected_interfaces": {
+    },
+    "modmenu": {
+      "badges": [ "library" ],
+      "parent": {
+        "id": "legacy-fabric-api",
+        "name": "Legacy Fabric API",
+        "badges": [ "library" ],
+        "description": "Core API module providing key hooks and inter-compatibility features for Minecraft 1.7.10-1.12.2.",
+        "icon": "assets/legacy-fabric/icon.png"
+      }
+    }
+  }
+}

--- a/legacy-fabric-entity-api-v1/1.7.10/src/main/resources/legacy-fabric-entity-api-v1.mixins.json
+++ b/legacy-fabric-entity-api-v1/1.7.10/src/main/resources/legacy-fabric-entity-api-v1.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "net.legacyfabric.fabric.mixin.entity",
+  "compatibilityLevel": "JAVA_8",
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "mixins": [
+    "EntityTypeMixin",
+    "SpawnEggDataAccessor"
+  ],
+  "client": [
+  ]
+}

--- a/legacy-fabric-entity-api-v1/1.8.9/gradle.properties
+++ b/legacy-fabric-entity-api-v1/1.8.9/gradle.properties
@@ -1,0 +1,2 @@
+minVersionIncluded=1.8.9
+maxVersionIncluded=1.8.9

--- a/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
+++ b/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.api.entity;
 
 import net.legacyfabric.fabric.api.util.Identifier;

--- a/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
+++ b/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
@@ -1,0 +1,10 @@
+package net.legacyfabric.fabric.api.entity;
+
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.impl.entity.versionned.EntityHelperImpl;
+
+public interface EntityHelper {
+	static void registerSpawnEgg(Identifier identifier, int color0, int color1) {
+		EntityHelperImpl.registerSpawnEgg(identifier, color0, color1);
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
+++ b/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
@@ -1,0 +1,47 @@
+package net.legacyfabric.fabric.impl.entity.versionned;
+
+import com.google.common.collect.Maps;
+
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
+
+import net.legacyfabric.fabric.mixin.entity.SpawnEggDataAccessor;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+
+import java.util.Map;
+
+public class EarlyInitializer implements PreLaunchEntrypoint {
+	@Override
+	public void onPreLaunch() {
+		RegistryInitializedEvent.event(RegistryIds.ENTITY_TYPES).register(EarlyInitializer::entityRegistryInit);
+	}
+
+	private static void entityRegistryInit(Registry<?> holder) {
+		SyncedRegistry<Class<? extends Entity>> registry = (SyncedRegistry<Class<? extends Entity>>) holder;
+
+		registry.fabric$getRegistryRemapCallback().register(changedIdsMap -> {
+			Map<Integer, EntityType.SpawnEggData> newMap = Maps.newLinkedHashMap();
+
+			for (Map.Entry<Integer, EntityType.SpawnEggData> entry : EntityType.SPAWN_EGGS.entrySet()) {
+				int id = entry.getKey();
+				EntityType.SpawnEggData spawnEggData = entry.getValue();
+
+				if (changedIdsMap.containsKey(id)) {
+					id = changedIdsMap.get(id).getId();
+					((SpawnEggDataAccessor) spawnEggData).setId(id);
+				}
+
+				newMap.put(id, spawnEggData);
+			}
+
+			EntityType.SPAWN_EGGS.clear();
+			EntityType.SPAWN_EGGS.putAll(newMap);
+		});
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
+++ b/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
@@ -1,20 +1,36 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.entity.versionned;
 
+import java.util.Map;
+
 import com.google.common.collect.Maps;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
 
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
-
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
 import net.legacyfabric.fabric.mixin.entity.SpawnEggDataAccessor;
-
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
-
-import java.util.Map;
 
 public class EarlyInitializer implements PreLaunchEntrypoint {
 	@Override
@@ -22,8 +38,8 @@ public class EarlyInitializer implements PreLaunchEntrypoint {
 		RegistryInitializedEvent.event(RegistryIds.ENTITY_TYPES).register(EarlyInitializer::entityRegistryInit);
 	}
 
-	private static void entityRegistryInit(Registry<?> holder) {
-		SyncedRegistry<Class<? extends Entity>> registry = (SyncedRegistry<Class<? extends Entity>>) holder;
+	private static void entityRegistryInit(FabricRegistry<?> holder) {
+		SyncedFabricRegistry<Class<? extends Entity>> registry = (SyncedFabricRegistry<Class<? extends Entity>>) holder;
 
 		registry.fabric$getRegistryRemapCallback().register(changedIdsMap -> {
 			Map<Integer, EntityType.SpawnEggData> newMap = Maps.newLinkedHashMap();

--- a/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
+++ b/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
@@ -1,10 +1,27 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.entity.versionned;
+
+import net.minecraft.entity.EntityType;
 
 import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.util.Identifier;
-
-import net.minecraft.entity.EntityType;
 
 public class EntityHelperImpl {
 	public static void registerSpawnEgg(Identifier identifier, int color0, int color1) {

--- a/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
+++ b/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
@@ -1,0 +1,15 @@
+package net.legacyfabric.fabric.impl.entity.versionned;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.util.Identifier;
+
+import net.minecraft.entity.EntityType;
+
+public class EntityHelperImpl {
+	public static void registerSpawnEgg(Identifier identifier, int color0, int color1) {
+		int mcId = RegistryHelper.getRawId(RegistryIds.ENTITY_TYPES,
+				RegistryHelper.getValue(RegistryIds.ENTITY_TYPES, identifier));
+		EntityType.SPAWN_EGGS.put(mcId, new EntityType.SpawnEggData(mcId, color0, color1));
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
+++ b/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
@@ -1,17 +1,23 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.mixin.entity;
 
-import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-
-import net.legacyfabric.fabric.api.util.Identifier;
-import net.legacyfabric.fabric.impl.entity.EntityHelperImpl;
-import net.legacyfabric.fabric.impl.entity.MapEntityRegistryWrapper;
-
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
+import java.util.Map;
 
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -22,7 +28,14 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Map;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.impl.entity.MapEntityRegistryWrapper;
 
 @Mixin(EntityType.class)
 public class EntityTypeMixin {
@@ -43,7 +56,7 @@ public class EntityTypeMixin {
 	private static Map<String, Integer> NAME_ID_MAP;
 
 	@Unique
-	private static Registry<Class<? extends Entity>> ENTITY_TYPE_REGISTRY;
+	private static FabricRegistry<Class<? extends Entity>> ENTITY_TYPE_REGISTRY;
 
 	@Inject(method = "load", at = @At("RETURN"))
 	private static void registerRegistry(CallbackInfo ci) {

--- a/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
+++ b/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
@@ -1,0 +1,77 @@
+package net.legacyfabric.fabric.mixin.entity;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.impl.entity.EntityHelperImpl;
+import net.legacyfabric.fabric.impl.entity.MapEntityRegistryWrapper;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Map;
+
+@Mixin(EntityType.class)
+public class EntityTypeMixin {
+	@Shadow
+	@Final
+	private static Map<String, Class<? extends Entity>> NAME_CLASS_MAP;
+	@Shadow
+	@Final
+	private static Map<Class<? extends Entity>, String> CLASS_NAME_MAP;
+	@Shadow
+	@Final
+	private static Map<Integer, Class<? extends Entity>> ID_CLASS_MAP;
+	@Shadow
+	@Final
+	private static Map<Class<? extends Entity>, Integer> CLASS_ID_MAP;
+	@Shadow
+	@Final
+	private static Map<String, Integer> NAME_ID_MAP;
+
+	@Unique
+	private static Registry<Class<? extends Entity>> ENTITY_TYPE_REGISTRY;
+
+	@Inject(method = "load", at = @At("RETURN"))
+	private static void registerRegistry(CallbackInfo ci) {
+		ENTITY_TYPE_REGISTRY = new MapEntityRegistryWrapper<>(
+				NAME_CLASS_MAP,
+				CLASS_NAME_MAP,
+				ID_CLASS_MAP,
+				CLASS_ID_MAP,
+				NAME_ID_MAP
+		);
+
+		RegistryHelper.addRegistry(RegistryIds.ENTITY_TYPES, ENTITY_TYPE_REGISTRY);
+	}
+
+	@ModifyArg(method = {"createInstanceFromName", "createInstanceFromNbt", "getIdByName"},
+			at = @At(value = "INVOKE", target = "Ljava/util/Map;get(Ljava/lang/Object;)Ljava/lang/Object;", remap = false))
+	private static Object fixOldRegistryNames(Object o) {
+		String key = (String) o;
+
+		if (key.contains(":")) {
+			Identifier identifier = new Identifier(key);
+			Class<? extends Entity> clazz = RegistryHelper.getValue(RegistryIds.ENTITY_TYPES, identifier);
+
+			if (clazz != null) {
+				key = CLASS_NAME_MAP.get(clazz);
+			}
+		}
+
+		return key;
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/entity/SpawnEggDataAccessor.java
+++ b/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/entity/SpawnEggDataAccessor.java
@@ -1,0 +1,12 @@
+package net.legacyfabric.fabric.mixin.entity;
+
+import net.minecraft.entity.EntityType;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(EntityType.SpawnEggData.class)
+public interface SpawnEggDataAccessor {
+	@Accessor
+	void setId(int id);
+}

--- a/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/entity/SpawnEggDataAccessor.java
+++ b/legacy-fabric-entity-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/entity/SpawnEggDataAccessor.java
@@ -1,9 +1,26 @@
-package net.legacyfabric.fabric.mixin.entity;
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import net.minecraft.entity.EntityType;
+package net.legacyfabric.fabric.mixin.entity;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.entity.EntityType;
 
 @Mixin(EntityType.SpawnEggData.class)
 public interface SpawnEggDataAccessor {

--- a/legacy-fabric-entity-api-v1/1.8.9/src/main/resources/fabric.mod.json
+++ b/legacy-fabric-entity-api-v1/1.8.9/src/main/resources/fabric.mod.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "id": "legacy-fabric-entity-api-v1",
+  "name": "Legacy Fabric Entity API (V1)",
+  "version": "${version}",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "icon": "assets/legacy-fabric/icon.png",
+  "contact": {
+    "homepage": "https://legacyfabric.net/",
+    "irc": "irc://irc.esper.net:6667/legacyfabric",
+    "issues": "https://github.com/Legacy-Fabric/fabric/issues",
+    "sources": "https://github.com/Legacy-Fabric/fabric"
+  },
+  "authors": [
+    "Legacy-Fabric"
+  ],
+  "depends": {
+    "fabricloader": ">=0.4.0",
+    "minecraft": "${minecraft_version}"
+  },
+  "description": "Entity utils",
+  "entrypoints": {
+    "preLaunch": [
+      "net.legacyfabric.fabric.impl.entity.versionned.EarlyInitializer"
+    ]
+  },
+  "mixins": [
+    "legacy-fabric-entity-api-v1.mixins.json"
+  ],
+  "custom": {
+    "loom:injected_interfaces": {
+    },
+    "modmenu": {
+      "badges": [ "library" ],
+      "parent": {
+        "id": "legacy-fabric-api",
+        "name": "Legacy Fabric API",
+        "badges": [ "library" ],
+        "description": "Core API module providing key hooks and inter-compatibility features for Minecraft 1.7.10-1.12.2.",
+        "icon": "assets/legacy-fabric/icon.png"
+      }
+    }
+  }
+}

--- a/legacy-fabric-entity-api-v1/1.8.9/src/main/resources/legacy-fabric-entity-api-v1.mixins.json
+++ b/legacy-fabric-entity-api-v1/1.8.9/src/main/resources/legacy-fabric-entity-api-v1.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "net.legacyfabric.fabric.mixin.entity",
+  "compatibilityLevel": "JAVA_8",
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "mixins": [
+    "EntityTypeMixin",
+    "SpawnEggDataAccessor"
+  ],
+  "client": [
+  ]
+}

--- a/legacy-fabric-entity-api-v1/1.8/gradle.properties
+++ b/legacy-fabric-entity-api-v1/1.8/gradle.properties
@@ -1,0 +1,2 @@
+minVersionIncluded=1.8
+maxVersionIncluded=1.8

--- a/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
+++ b/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.api.entity;
 
 import net.legacyfabric.fabric.api.util.Identifier;

--- a/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
+++ b/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/api/entity/EntityHelper.java
@@ -1,0 +1,10 @@
+package net.legacyfabric.fabric.api.entity;
+
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.impl.entity.versionned.EntityHelperImpl;
+
+public interface EntityHelper {
+	static void registerSpawnEgg(Identifier identifier, int color0, int color1) {
+		EntityHelperImpl.registerSpawnEgg(identifier, color0, color1);
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
+++ b/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
@@ -1,21 +1,37 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.entity.versionned;
 
+import java.util.Map;
+
 import com.google.common.collect.Maps;
-
-import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
-
-import net.legacyfabric.fabric.mixin.entity.SpawnEggDataAccessor;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.class_868;
 
-import java.util.Map;
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
+import net.legacyfabric.fabric.mixin.entity.SpawnEggDataAccessor;
 
 public class EarlyInitializer implements PreLaunchEntrypoint {
 	@Override
@@ -23,8 +39,8 @@ public class EarlyInitializer implements PreLaunchEntrypoint {
 		RegistryInitializedEvent.event(RegistryIds.ENTITY_TYPES).register(EarlyInitializer::entityRegistryInit);
 	}
 
-	private static void entityRegistryInit(Registry<?> holder) {
-		SyncedRegistry<Class<? extends Entity>> registry = (SyncedRegistry<Class<? extends Entity>>) holder;
+	private static void entityRegistryInit(FabricRegistry<?> holder) {
+		SyncedFabricRegistry<Class<? extends Entity>> registry = (SyncedFabricRegistry<Class<? extends Entity>>) holder;
 
 		registry.fabric$getRegistryRemapCallback().register(changedIdsMap -> {
 			Map<Integer, class_868> newMap = Maps.newLinkedHashMap();
@@ -36,7 +52,7 @@ public class EarlyInitializer implements PreLaunchEntrypoint {
 
 				if (changedIdsMap.containsKey(id)) {
 					id = changedIdsMap.get(id).getId();
-					((SpawnEggDataAccessor) spawnEggData).setField_3273(id);
+					((SpawnEggDataAccessor) spawnEggData).setId(id);
 				}
 
 				newMap.put(id, spawnEggData);

--- a/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
+++ b/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EarlyInitializer.java
@@ -1,0 +1,49 @@
+package net.legacyfabric.fabric.impl.entity.versionned;
+
+import com.google.common.collect.Maps;
+
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
+
+import net.legacyfabric.fabric.mixin.entity.SpawnEggDataAccessor;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.class_868;
+
+import java.util.Map;
+
+public class EarlyInitializer implements PreLaunchEntrypoint {
+	@Override
+	public void onPreLaunch() {
+		RegistryInitializedEvent.event(RegistryIds.ENTITY_TYPES).register(EarlyInitializer::entityRegistryInit);
+	}
+
+	private static void entityRegistryInit(Registry<?> holder) {
+		SyncedRegistry<Class<? extends Entity>> registry = (SyncedRegistry<Class<? extends Entity>>) holder;
+
+		registry.fabric$getRegistryRemapCallback().register(changedIdsMap -> {
+			Map<Integer, class_868> newMap = Maps.newLinkedHashMap();
+
+			for (Object entry1 : EntityType.SPAWN_EGGS.entrySet()) {
+				Map.Entry<Object, Object> entry = (Map.Entry) entry1;
+				int id = (int) entry.getKey();
+				class_868 spawnEggData = (class_868) entry.getValue();
+
+				if (changedIdsMap.containsKey(id)) {
+					id = changedIdsMap.get(id).getId();
+					((SpawnEggDataAccessor) spawnEggData).setField_3273(id);
+				}
+
+				newMap.put(id, spawnEggData);
+			}
+
+			EntityType.SPAWN_EGGS.clear();
+			EntityType.SPAWN_EGGS.putAll(newMap);
+		});
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
+++ b/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
@@ -1,0 +1,16 @@
+package net.legacyfabric.fabric.impl.entity.versionned;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.util.Identifier;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.class_868;
+
+public class EntityHelperImpl {
+	public static void registerSpawnEgg(Identifier identifier, int color0, int color1) {
+		int mcId = RegistryHelper.getRawId(RegistryIds.ENTITY_TYPES,
+				RegistryHelper.getValue(RegistryIds.ENTITY_TYPES, identifier));
+		EntityType.SPAWN_EGGS.put(mcId, new class_868(mcId, color0, color1));
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
+++ b/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/impl/entity/versionned/EntityHelperImpl.java
@@ -1,11 +1,28 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.entity.versionned;
+
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.class_868;
 
 import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.util.Identifier;
-
-import net.minecraft.entity.EntityType;
-import net.minecraft.entity.class_868;
 
 public class EntityHelperImpl {
 	public static void registerSpawnEgg(Identifier identifier, int color0, int color1) {

--- a/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
+++ b/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
@@ -1,17 +1,23 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.mixin.entity;
 
-import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-
-import net.legacyfabric.fabric.api.util.Identifier;
-import net.legacyfabric.fabric.impl.entity.EntityHelperImpl;
-import net.legacyfabric.fabric.impl.entity.MapEntityRegistryWrapper;
-
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityType;
+import java.util.Map;
 
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -22,7 +28,14 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Map;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.impl.entity.MapEntityRegistryWrapper;
 
 @Mixin(EntityType.class)
 public class EntityTypeMixin {
@@ -43,7 +56,7 @@ public class EntityTypeMixin {
 	private static Map<String, Integer> NAME_ID_MAP;
 
 	@Unique
-	private static Registry<Class<? extends Entity>> ENTITY_TYPE_REGISTRY;
+	private static FabricRegistry<Class<? extends Entity>> ENTITY_TYPE_REGISTRY;
 
 	@Inject(method = "load", at = @At("RETURN"))
 	private static void registerRegistry(CallbackInfo ci) {

--- a/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
+++ b/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/mixin/entity/EntityTypeMixin.java
@@ -1,0 +1,77 @@
+package net.legacyfabric.fabric.mixin.entity;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.impl.entity.EntityHelperImpl;
+import net.legacyfabric.fabric.impl.entity.MapEntityRegistryWrapper;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Map;
+
+@Mixin(EntityType.class)
+public class EntityTypeMixin {
+	@Shadow
+	@Final
+	private static Map<String, Class<? extends Entity>> NAME_CLASS_MAP;
+	@Shadow
+	@Final
+	private static Map<Class<? extends Entity>, String> CLASS_NAME_MAP;
+	@Shadow
+	@Final
+	private static Map<Integer, Class<? extends Entity>> ID_CLASS_MAP;
+	@Shadow
+	@Final
+	private static Map<Class<? extends Entity>, Integer> CLASS_ID_MAP;
+	@Shadow
+	@Final
+	private static Map<String, Integer> NAME_ID_MAP;
+
+	@Unique
+	private static Registry<Class<? extends Entity>> ENTITY_TYPE_REGISTRY;
+
+	@Inject(method = "load", at = @At("RETURN"))
+	private static void registerRegistry(CallbackInfo ci) {
+		ENTITY_TYPE_REGISTRY = new MapEntityRegistryWrapper<>(
+				NAME_CLASS_MAP,
+				CLASS_NAME_MAP,
+				ID_CLASS_MAP,
+				CLASS_ID_MAP,
+				NAME_ID_MAP
+		);
+
+		RegistryHelper.addRegistry(RegistryIds.ENTITY_TYPES, ENTITY_TYPE_REGISTRY);
+	}
+
+	@ModifyArg(method = {"createInstanceFromName", "createInstanceFromNbt", "getIdByName"},
+			at = @At(value = "INVOKE", target = "Ljava/util/Map;get(Ljava/lang/Object;)Ljava/lang/Object;", remap = false))
+	private static Object fixOldRegistryNames(Object o) {
+		String key = (String) o;
+
+		if (key.contains(":")) {
+			Identifier identifier = new Identifier(key);
+			Class<? extends Entity> clazz = RegistryHelper.getValue(RegistryIds.ENTITY_TYPES, identifier);
+
+			if (clazz != null) {
+				key = CLASS_NAME_MAP.get(clazz);
+			}
+		}
+
+		return key;
+	}
+}

--- a/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/mixin/entity/SpawnEggDataAccessor.java
+++ b/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/mixin/entity/SpawnEggDataAccessor.java
@@ -1,12 +1,29 @@
-package net.legacyfabric.fabric.mixin.entity;
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import net.minecraft.entity.class_868;
+package net.legacyfabric.fabric.mixin.entity;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
+import net.minecraft.entity.class_868;
+
 @Mixin(class_868.class)
 public interface SpawnEggDataAccessor {
-	@Accessor
-	void setField_3273(int id);
+	@Accessor("field_3273")
+	void setId(int id);
 }

--- a/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/mixin/entity/SpawnEggDataAccessor.java
+++ b/legacy-fabric-entity-api-v1/1.8/src/main/java/net/legacyfabric/fabric/mixin/entity/SpawnEggDataAccessor.java
@@ -1,0 +1,12 @@
+package net.legacyfabric.fabric.mixin.entity;
+
+import net.minecraft.entity.class_868;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(class_868.class)
+public interface SpawnEggDataAccessor {
+	@Accessor
+	void setField_3273(int id);
+}

--- a/legacy-fabric-entity-api-v1/1.8/src/main/resources/fabric.mod.json
+++ b/legacy-fabric-entity-api-v1/1.8/src/main/resources/fabric.mod.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "id": "legacy-fabric-entity-api-v1",
+  "name": "Legacy Fabric Entity API (V1)",
+  "version": "${version}",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "icon": "assets/legacy-fabric/icon.png",
+  "contact": {
+    "homepage": "https://legacyfabric.net/",
+    "irc": "irc://irc.esper.net:6667/legacyfabric",
+    "issues": "https://github.com/Legacy-Fabric/fabric/issues",
+    "sources": "https://github.com/Legacy-Fabric/fabric"
+  },
+  "authors": [
+    "Legacy-Fabric"
+  ],
+  "depends": {
+    "fabricloader": ">=0.4.0",
+    "minecraft": "${minecraft_version}"
+  },
+  "description": "Entity utils",
+  "entrypoints": {
+    "preLaunch": [
+      "net.legacyfabric.fabric.impl.entity.versionned.EarlyInitializer"
+    ]
+  },
+  "mixins": [
+    "legacy-fabric-entity-api-v1.mixins.json"
+  ],
+  "custom": {
+    "loom:injected_interfaces": {
+    },
+    "modmenu": {
+      "badges": [ "library" ],
+      "parent": {
+        "id": "legacy-fabric-api",
+        "name": "Legacy Fabric API",
+        "badges": [ "library" ],
+        "description": "Core API module providing key hooks and inter-compatibility features for Minecraft 1.7.10-1.12.2.",
+        "icon": "assets/legacy-fabric/icon.png"
+      }
+    }
+  }
+}

--- a/legacy-fabric-entity-api-v1/1.8/src/main/resources/legacy-fabric-entity-api-v1.mixins.json
+++ b/legacy-fabric-entity-api-v1/1.8/src/main/resources/legacy-fabric-entity-api-v1.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "net.legacyfabric.fabric.mixin.entity",
+  "compatibilityLevel": "JAVA_8",
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "mixins": [
+    "EntityTypeMixin",
+    "SpawnEggDataAccessor"
+  ],
+  "client": [
+  ]
+}

--- a/legacy-fabric-entity-api-v1/common.gradle
+++ b/legacy-fabric-entity-api-v1/common.gradle
@@ -1,0 +1,6 @@
+moduleDependencies(project, [
+    "legacy-fabric-api-base",
+	"legacy-fabric-networking-api-v1",
+	"legacy-fabric-resource-loader-v1",
+	"legacy-fabric-registry-sync-api-v2"
+])

--- a/legacy-fabric-entity-api-v1/common/gradle.properties
+++ b/legacy-fabric-entity-api-v1/common/gradle.properties
@@ -1,0 +1,2 @@
+minVersionIncluded=1.7
+maxVersionIncluded=1.12.2

--- a/legacy-fabric-entity-api-v1/common/src/main/java/net/legacyfabric/fabric/api/entity/EntityTypeIds.java
+++ b/legacy-fabric-entity-api-v1/common/src/main/java/net/legacyfabric/fabric/api/entity/EntityTypeIds.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.api.entity;
+
+import net.legacyfabric.fabric.api.util.BeforeMC;
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.api.util.SinceMC;
+
+public class EntityTypeIds {
+	public static final Identifier ITEM = id("item");
+	public static final Identifier XP_ORB = id("xp_orb");
+	@SinceMC("1.9")
+	public static final Identifier AREA_EFFECT_CLOUD = id("area_effect_cloud");
+	@SinceMC("1.11")
+	public static final Identifier ELDER_GUARDIAN = id("elder_guardian");
+	@SinceMC("1.11")
+	public static final Identifier WITHER_SKELETON = id("wither_skeleton");
+	@SinceMC("1.11")
+	public static final Identifier STRAY = id("stray");
+	@SinceMC("1.8.9")
+	public static final Identifier EGG = id("egg");
+	public static final Identifier LEASH_KNOT = id("leash_knot");
+	public static final Identifier PAINTING = id("painting");
+	public static final Identifier ARROW = id("arrow");
+	public static final Identifier SNOWBALL = id("snowball");
+	public static final Identifier FIREBALL = id("fireball");
+	public static final Identifier SMALL_FIREBALL = id("small_fireball");
+	public static final Identifier ENDER_PEARL = id("ender_pearl");
+	public static final Identifier EYE_OF_ENDER = id("eye_of_ender_signal");
+	public static final Identifier POTION = id("potion");
+	public static final Identifier XP_BOTTLE = id("xp_bottle");
+	public static final Identifier ITEM_FRAME = id("item_frame");
+	public static final Identifier WITHER_SKULL = id("wither_skull");
+	public static final Identifier TNT = id("tnt");
+	public static final Identifier FALLING_BLOCK = id("falling_block");
+	public static final Identifier FIREWORKS_ROCKET = id("fireworks_rocket");
+	@SinceMC("1.11")
+	public static final Identifier HUSK = id("husk");
+	@SinceMC("1.9")
+	public static final Identifier SPECTRAL_ARROW = id("spectral_arrow");
+	@SinceMC("1.9")
+	public static final Identifier SHULKER_BULLET = id("shulker_bullet");
+	@SinceMC("1.9")
+	public static final Identifier DRAGON_FIREBALL = id("dragon_fireball");
+	@SinceMC("1.11")
+	public static final Identifier ZOMBIE_VILLAGER = id("zombie_villager");
+	@SinceMC("1.11")
+	public static final Identifier SKELETON_HORSE = id("skeleton_horse");
+	@SinceMC("1.11")
+	public static final Identifier ZOMBIE_HORSE = id("zombie_horse");
+	@SinceMC("1.8")
+	public static final Identifier ARMOR_STAND = id("armor_stand");
+	@SinceMC("1.11")
+	public static final Identifier DONKEY = id("donkey");
+	@SinceMC("1.11")
+	public static final Identifier MULE = id("mule");
+	@SinceMC("1.11")
+	public static final Identifier EVOCATOR_FANGS = id("evocation_fangs");
+	@SinceMC("1.11")
+	public static final Identifier EVOCATOR = id("evocation_illager");
+	@SinceMC("1.11")
+	public static final Identifier VEX = id("vex");
+	@SinceMC("1.11")
+	public static final Identifier VINDICATOR = id("vindication_illager");
+	@SinceMC("1.12")
+	public static final Identifier ILLUSIONER = id("illusion_illager");
+	public static final Identifier COMMAND_BLOCK_MINECART = id("commandblock_minecart");
+	public static final Identifier BOAT = id("boat");
+	public static final Identifier MINECART = id("minecart");
+	public static final Identifier CHEST_MINECART = id("chest_minecart");
+	public static final Identifier FURNACE_MINECART = id("furnace_minecart");
+	public static final Identifier TNT_MINECART = id("tnt_minecart");
+	public static final Identifier HOPPER_MINECART = id("hopper_minecart");
+	public static final Identifier SPAWNER_MINECART = id("spawner_minecart");
+	@BeforeMC("1.11")
+	public static final Identifier MOB = id("mod");
+	@BeforeMC("1.11")
+	public static final Identifier MONSTER = id("monster");
+	public static final Identifier CREEPER = id("creeper");
+	public static final Identifier SKELETON = id("skeleton");
+	public static final Identifier SPIDER = id("spider");
+	public static final Identifier GIANT = id("giant");
+	public static final Identifier ZOMBIE = id("zombie");
+	public static final Identifier SLIME = id("slime");
+	public static final Identifier GHAST = id("ghast");
+	public static final Identifier ZOMBIE_PIGMAN = id("zombie_pigman");
+	public static final Identifier ENDERMAN = id("enderman");
+	public static final Identifier CAVE_SPIDER = id("cave_spider");
+	public static final Identifier SILVERFISH = id("silverfish");
+	public static final Identifier BLAZE = id("blaze");
+	public static final Identifier MAGMA_CUBE = id("magma_cube");
+	public static final Identifier ENDER_DRAGON = id("ender_dragon");
+	public static final Identifier WITHER_BOSS = id("wither");
+	public static final Identifier BAT = id("bat");
+	public static final Identifier WITCH = id("witch");
+	@SinceMC("1.8")
+	public static final Identifier ENDERMITE = id("endermite");
+	@SinceMC("1.8")
+	public static final Identifier GUARDIAN = id("guardian");
+	@SinceMC("1.9")
+	public static final Identifier SHULKER = id("shulker");
+	public static final Identifier PIG = id("pig");
+	public static final Identifier SHEEP = id("sheep");
+	public static final Identifier COW = id("cow");
+	public static final Identifier CHICKEN = id("chicken");
+	public static final Identifier SQUID = id("squid");
+	public static final Identifier WOLF = id("wolf");
+	public static final Identifier MOOSHROOM = id("mooshroom");
+	public static final Identifier SNOWMAN = id("snowman");
+	public static final Identifier OCELOT = id("ocelot");
+	public static final Identifier IRON_GOLEM = id("villager_golem");
+	public static final Identifier HORSE = id("horse");
+	@SinceMC("1.8")
+	public static final Identifier RABBIT = id("rabbit");
+	@SinceMC("1.10")
+	public static final Identifier POLAR_BEAR = id("polar_bear");
+	@SinceMC("1.11")
+	public static final Identifier LLAMA = id("llama");
+	@SinceMC("1.11")
+	public static final Identifier LLAMA_SPIT = id("llama_spit");
+	@SinceMC("1.12")
+	public static final Identifier PARROT = id("parrot");
+	public static final Identifier VILLAGER = id("villager");
+	public static final Identifier ENDER_CRYSTAL = id("ender_crystal");
+	public static final Identifier LIGHTNING_BOLT = id("lightning_bolt");
+	public static final Identifier PLAYER = id("player");
+
+	private static Identifier id(String path) {
+		return new Identifier(path);
+	}
+}

--- a/legacy-fabric-entity-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/entity/EntityHelperImpl.java
+++ b/legacy-fabric-entity-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/entity/EntityHelperImpl.java
@@ -1,7 +1,23 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.entity;
 
 import com.google.common.collect.BiMap;
-
 import com.google.common.collect.HashBiMap;
 
 import net.legacyfabric.fabric.api.entity.EntityTypeIds;
@@ -10,7 +26,7 @@ import net.legacyfabric.fabric.api.util.Identifier;
 public class EntityHelperImpl {
 	public static final BiMap<String, Identifier> NAME_TO_ID = HashBiMap.create();
 	public static final BiMap<Identifier, String> ID_TO_NAME = NAME_TO_ID.inverse();
-	
+
 	static {
 		NAME_TO_ID.put("Item", EntityTypeIds.ITEM);
 		NAME_TO_ID.put("XPOrb", EntityTypeIds.XP_ORB);

--- a/legacy-fabric-entity-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/entity/EntityHelperImpl.java
+++ b/legacy-fabric-entity-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/entity/EntityHelperImpl.java
@@ -1,0 +1,86 @@
+package net.legacyfabric.fabric.impl.entity;
+
+import com.google.common.collect.BiMap;
+
+import com.google.common.collect.HashBiMap;
+
+import net.legacyfabric.fabric.api.entity.EntityTypeIds;
+import net.legacyfabric.fabric.api.util.Identifier;
+
+public class EntityHelperImpl {
+	public static final BiMap<String, Identifier> NAME_TO_ID = HashBiMap.create();
+	public static final BiMap<Identifier, String> ID_TO_NAME = NAME_TO_ID.inverse();
+	
+	static {
+		NAME_TO_ID.put("Item", EntityTypeIds.ITEM);
+		NAME_TO_ID.put("XPOrb", EntityTypeIds.XP_ORB);
+		NAME_TO_ID.put("AreaEffectCloud", EntityTypeIds.AREA_EFFECT_CLOUD);
+		NAME_TO_ID.put("ThrownEgg", EntityTypeIds.EGG);
+		NAME_TO_ID.put("LeashKnot", EntityTypeIds.LEASH_KNOT);
+		NAME_TO_ID.put("Painting", EntityTypeIds.PAINTING);
+		NAME_TO_ID.put("Arrow", EntityTypeIds.ARROW);
+		NAME_TO_ID.put("Snowball", EntityTypeIds.SNOWBALL);
+		NAME_TO_ID.put("Fireball", EntityTypeIds.FIREBALL);
+		NAME_TO_ID.put("SmallFireball", EntityTypeIds.SMALL_FIREBALL);
+		NAME_TO_ID.put("ThrownEnderpearl", EntityTypeIds.ENDER_PEARL);
+		NAME_TO_ID.put("EyeOfEnderSignal", EntityTypeIds.EYE_OF_ENDER);
+		NAME_TO_ID.put("ThrownPotion", EntityTypeIds.POTION);
+		NAME_TO_ID.put("ThrownExpBottle", EntityTypeIds.XP_BOTTLE);
+		NAME_TO_ID.put("ItemFrame", EntityTypeIds.ITEM_FRAME);
+		NAME_TO_ID.put("WitherSkull", EntityTypeIds.WITHER_SKULL);
+		NAME_TO_ID.put("PrimedTnt", EntityTypeIds.TNT);
+		NAME_TO_ID.put("FallingSand", EntityTypeIds.FALLING_BLOCK);
+		NAME_TO_ID.put("FireworksRocketEntity", EntityTypeIds.FIREWORKS_ROCKET);
+		NAME_TO_ID.put("SpectralArrow", EntityTypeIds.SPECTRAL_ARROW);
+		NAME_TO_ID.put("ShulkerBullet", EntityTypeIds.SHULKER_BULLET);
+		NAME_TO_ID.put("DragonFireball", EntityTypeIds.DRAGON_FIREBALL);
+		NAME_TO_ID.put("ArmorStand", EntityTypeIds.ARMOR_STAND);
+		NAME_TO_ID.put("MinecartCommandBlock", EntityTypeIds.COMMAND_BLOCK_MINECART);
+		NAME_TO_ID.put("Boat", EntityTypeIds.BOAT);
+		NAME_TO_ID.put("MinecartRideable", EntityTypeIds.MINECART);
+		NAME_TO_ID.put("MinecartChest", EntityTypeIds.CHEST_MINECART);
+		NAME_TO_ID.put("MinecartFurnace", EntityTypeIds.FURNACE_MINECART);
+		NAME_TO_ID.put("MinecartTNT", EntityTypeIds.TNT_MINECART);
+		NAME_TO_ID.put("MinecartHopper", EntityTypeIds.HOPPER_MINECART);
+		NAME_TO_ID.put("MinecartSpawner", EntityTypeIds.SPAWNER_MINECART);
+		NAME_TO_ID.put("Mob", EntityTypeIds.MOB);
+		NAME_TO_ID.put("Monster", EntityTypeIds.MONSTER);
+		NAME_TO_ID.put("Creeper", EntityTypeIds.CREEPER);
+		NAME_TO_ID.put("Skeleton", EntityTypeIds.SKELETON);
+		NAME_TO_ID.put("Spider", EntityTypeIds.SPIDER);
+		NAME_TO_ID.put("Giant", EntityTypeIds.GIANT);
+		NAME_TO_ID.put("Zombie", EntityTypeIds.ZOMBIE);
+		NAME_TO_ID.put("Slime", EntityTypeIds.SLIME);
+		NAME_TO_ID.put("Ghast", EntityTypeIds.GHAST);
+		NAME_TO_ID.put("PigZombie", EntityTypeIds.ZOMBIE_PIGMAN);
+		NAME_TO_ID.put("Enderman", EntityTypeIds.ENDERMAN);
+		NAME_TO_ID.put("CaveSpider", EntityTypeIds.CAVE_SPIDER);
+		NAME_TO_ID.put("Silverfish", EntityTypeIds.SILVERFISH);
+		NAME_TO_ID.put("Blaze", EntityTypeIds.BLAZE);
+		NAME_TO_ID.put("LavaSlime", EntityTypeIds.MAGMA_CUBE);
+		NAME_TO_ID.put("EnderDragon", EntityTypeIds.ENDER_DRAGON);
+		NAME_TO_ID.put("WitherBoss", EntityTypeIds.WITHER_BOSS);
+		NAME_TO_ID.put("Bat", EntityTypeIds.BAT);
+		NAME_TO_ID.put("Witch", EntityTypeIds.WITCH);
+		NAME_TO_ID.put("Endermite", EntityTypeIds.ENDERMITE);
+		NAME_TO_ID.put("Guardian", EntityTypeIds.GUARDIAN);
+		NAME_TO_ID.put("Shulker", EntityTypeIds.SHULKER);
+		NAME_TO_ID.put("Pig", EntityTypeIds.PIG);
+		NAME_TO_ID.put("Sheep", EntityTypeIds.SHEEP);
+		NAME_TO_ID.put("Cow", EntityTypeIds.COW);
+		NAME_TO_ID.put("Chicken", EntityTypeIds.CHICKEN);
+		NAME_TO_ID.put("Squid", EntityTypeIds.SQUID);
+		NAME_TO_ID.put("Wolf", EntityTypeIds.WOLF);
+		NAME_TO_ID.put("MushroomCow", EntityTypeIds.MOOSHROOM);
+		NAME_TO_ID.put("SnowMan", EntityTypeIds.SNOWMAN);
+		NAME_TO_ID.put("Ozelot", EntityTypeIds.OCELOT);
+		NAME_TO_ID.put("VillagerGolem", EntityTypeIds.IRON_GOLEM);
+		NAME_TO_ID.put("EntityHorse", EntityTypeIds.HORSE);
+		NAME_TO_ID.put("Rabbit", EntityTypeIds.RABBIT);
+		NAME_TO_ID.put("PolarBear", EntityTypeIds.POLAR_BEAR);
+		NAME_TO_ID.put("Villager", EntityTypeIds.VILLAGER);
+		NAME_TO_ID.put("EnderCrystal", EntityTypeIds.ENDER_CRYSTAL);
+		NAME_TO_ID.put("Player", EntityTypeIds.PLAYER);
+		NAME_TO_ID.put("LightningBolt", EntityTypeIds.LIGHTNING_BOLT);
+	}
+}

--- a/legacy-fabric-entity-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/entity/MapEntityRegistryWrapper.java
+++ b/legacy-fabric-entity-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/entity/MapEntityRegistryWrapper.java
@@ -1,0 +1,165 @@
+package net.legacyfabric.fabric.impl.entity;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+
+import net.legacyfabric.fabric.api.event.Event;
+import net.legacyfabric.fabric.api.event.EventFactory;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryBeforeAddCallback;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryEntryAddedCallback;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryRemapCallback;
+import net.legacyfabric.fabric.api.registry.v2.registry.SyncedRegistrableRegistry;
+
+import net.legacyfabric.fabric.api.registry.v2.registry.registrable.IdsHolder;
+import net.legacyfabric.fabric.api.util.Identifier;
+
+import net.legacyfabric.fabric.impl.registry.IdsHolderImpl;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public class MapEntityRegistryWrapper<V> implements SyncedRegistrableRegistry<V> {
+	private final Identifier id = RegistryIds.ENTITY_TYPES;
+
+	private final Event<RegistryEntryAddedCallback<V>> addObjectEvent = EventFactory.createArrayBacked(RegistryEntryAddedCallback.class,
+			(callbacks) -> (rawId, id, object) -> {
+				for (RegistryEntryAddedCallback<V> callback : callbacks) {
+					callback.onEntryAdded(rawId, id, object);
+				}
+			}
+	);
+	private final Event<RegistryBeforeAddCallback<V>> beforeAddObjectEvent = EventFactory.createArrayBacked(RegistryBeforeAddCallback.class,
+			(callbacks) -> (rawId, id, object) -> {
+				for (RegistryBeforeAddCallback<V> callback : callbacks) {
+					callback.onEntryAdding(rawId, id, object);
+				}
+			}
+	);
+	private final Event<RegistryRemapCallback<V>> remapCallbackEvent = EventFactory.createArrayBacked(RegistryRemapCallback.class,
+			(callbacks) -> (changedMap) -> {
+				for (RegistryRemapCallback<V> callback : callbacks) {
+					callback.callback(changedMap);
+				}
+			}
+	);
+
+	private final Map<String, V> nameToValue;
+	private final Map<V, String> valueToName;
+	private final Map<Integer, V> idToValue;
+	private final Map<V, Integer> valueToId;
+	private final Map<String, Integer> nameToId;
+
+	private IdsHolder<V> idsHolder = new IdsHolderImpl<>(1);
+	private final BiMap<Identifier, V> keyToValue = HashBiMap.create();
+	private final BiMap<V, Identifier> valueToKey = keyToValue.inverse();
+
+	public MapEntityRegistryWrapper(Map<String, V> nameToValue, Map<V, String> valueToName, Map<Integer, V> idToValue, Map<V, Integer> valueToId, Map<String, Integer> nameToId) {
+		this.nameToValue = nameToValue;
+		this.valueToName = valueToName;
+		this.idToValue = idToValue;
+		this.valueToId = valueToId;
+		this.nameToId = nameToId;
+
+		for (Map.Entry<Integer, V> entry : idToValue.entrySet()) {
+			this.idsHolder.fabric$setValue(entry.getValue(), entry.getKey());
+		}
+
+		for (Map.Entry<String, V> entry : nameToValue.entrySet()) {
+			this.keyToValue.put(EntityHelperImpl.NAME_TO_ID.get(entry.getKey()), entry.getValue());
+		}
+	}
+
+	@Override
+	public int fabric$getRawId(V value) {
+		return this.idsHolder.fabric$getId(value);
+	}
+
+	@Override
+	public V fabric$getValue(int rawId) {
+		return this.idsHolder.fabric$getValue(rawId);
+	}
+
+	@Override
+	public Event<RegistryRemapCallback<V>> fabric$getRegistryRemapCallback() {
+		return this.remapCallbackEvent;
+	}
+
+	@Override
+	public Identifier fabric$getId() {
+		return this.id;
+	}
+
+	@Override
+	public Event<RegistryEntryAddedCallback<V>> fabric$getEntryAddedCallback() {
+		return this.addObjectEvent;
+	}
+
+	@Override
+	public Event<RegistryBeforeAddCallback<V>> fabric$getBeforeAddedCallback() {
+		return this.beforeAddObjectEvent;
+	}
+
+	@Override
+	public Identifier fabric$toKeyType(Identifier identifier) {
+		return identifier;
+	}
+
+	@Override
+	public V fabric$getValue(Identifier id) {
+		return this.keyToValue.get(id);
+	}
+
+	@Override
+	public Identifier fabric$getId(V value) {
+		return this.valueToKey.get(value);
+	}
+
+	@NotNull
+	@Override
+	public Iterator<V> iterator() {
+		return this.idsHolder.iterator();
+	}
+
+	@Override
+	public IdsHolder<V> fabric$getIdsHolder() {
+		return this.idsHolder;
+	}
+
+	@Override
+	public void fabric$updateRegistry(IdsHolder<V> ids) {
+		this.idsHolder = ids;
+
+		this.idToValue.clear();
+		this.valueToId.clear();
+		this.nameToId.clear();
+
+		for (Map.Entry<String, V> entry : this.nameToValue.entrySet()) {
+			int id = this.idsHolder.fabric$getId(entry.getValue());
+
+			this.idToValue.put(id, entry.getValue());
+			this.valueToId.put(entry.getValue(), id);
+			this.nameToId.put(entry.getKey(), id);
+		}
+	}
+
+	@Override
+	public void fabric$register(int rawId, Identifier identifier, V value) {
+		beforeAddObjectEvent.invoker().onEntryAdding(rawId, identifier, value);
+
+		String name = identifier.toTranslationKey();
+
+		nameToValue.put(name, value);
+		valueToName.put(value, name);
+		idToValue.put(rawId, value);
+		valueToId.put(value, rawId);
+		nameToId.put(name, rawId);
+
+		keyToValue.put(identifier, value);
+		idsHolder.fabric$setValue(value, rawId);
+
+		addObjectEvent.invoker().onEntryAdded(rawId, identifier, value);
+	}
+}

--- a/legacy-fabric-entity-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/entity/MapEntityRegistryWrapper.java
+++ b/legacy-fabric-entity-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/entity/MapEntityRegistryWrapper.java
@@ -1,7 +1,28 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.entity;
+
+import java.util.Iterator;
+import java.util.Map;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import org.jetbrains.annotations.NotNull;
 
 import net.legacyfabric.fabric.api.event.Event;
 import net.legacyfabric.fabric.api.event.EventFactory;
@@ -9,19 +30,12 @@ import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.registry.v2.event.RegistryBeforeAddCallback;
 import net.legacyfabric.fabric.api.registry.v2.event.RegistryEntryAddedCallback;
 import net.legacyfabric.fabric.api.registry.v2.event.RegistryRemapCallback;
-import net.legacyfabric.fabric.api.registry.v2.registry.SyncedRegistrableRegistry;
-
+import net.legacyfabric.fabric.api.registry.v2.registry.SyncedRegistrableFabricRegistry;
 import net.legacyfabric.fabric.api.registry.v2.registry.registrable.IdsHolder;
 import net.legacyfabric.fabric.api.util.Identifier;
-
 import net.legacyfabric.fabric.impl.registry.IdsHolderImpl;
 
-import org.jetbrains.annotations.NotNull;
-
-import java.util.Iterator;
-import java.util.Map;
-
-public class MapEntityRegistryWrapper<V> implements SyncedRegistrableRegistry<V> {
+public class MapEntityRegistryWrapper<V> implements SyncedRegistrableFabricRegistry<V> {
 	private final Identifier id = RegistryIds.ENTITY_TYPES;
 
 	private final Event<RegistryEntryAddedCallback<V>> addObjectEvent = EventFactory.createArrayBacked(RegistryEntryAddedCallback.class,

--- a/legacy-fabric-entity-api-v1/common/src/main/resources/fabric.mod.json
+++ b/legacy-fabric-entity-api-v1/common/src/main/resources/fabric.mod.json
@@ -1,0 +1,43 @@
+{
+  "schemaVersion": 1,
+  "id": "legacy-fabric-entity-api-v1-common",
+  "name": "Legacy Fabric Entity API (V1)",
+  "version": "${version}",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "icon": "assets/legacy-fabric/icon.png",
+  "contact": {
+    "homepage": "https://legacyfabric.net/",
+    "irc": "irc://irc.esper.net:6667/legacyfabric",
+    "issues": "https://github.com/Legacy-Fabric/fabric/issues",
+    "sources": "https://github.com/Legacy-Fabric/fabric"
+  },
+  "authors": [
+    "Legacy-Fabric"
+  ],
+  "depends": {
+    "fabricloader": ">=0.4.0",
+    "minecraft": "${minecraft_version}"
+  },
+  "description": "Entity utils",
+  "entrypoints": {
+    "preLaunch": [
+    ]
+  },
+  "mixins": [
+  ],
+  "custom": {
+    "loom:injected_interfaces": {
+    },
+    "modmenu": {
+      "badges": [ "library" ],
+      "parent": {
+        "id": "legacy-fabric-api",
+        "name": "Legacy Fabric API",
+        "badges": [ "library" ],
+        "description": "Core API module providing key hooks and inter-compatibility features for Minecraft 1.7.10-1.12.2.",
+        "icon": "assets/legacy-fabric/icon.png"
+      }
+    }
+  }
+}

--- a/legacy-fabric-registry-sync-api-v1/common.gradle
+++ b/legacy-fabric-registry-sync-api-v1/common.gradle
@@ -6,5 +6,6 @@ moduleDependencies(project, [
 	"legacy-fabric-item-api-v1",
 	"legacy-fabric-block-api-v1",
 	"legacy-fabric-block-entity-api-v1",
-	"legacy-fabric-effect-api-v1"
+	"legacy-fabric-effect-api-v1",
+	"legacy-fabric-entity-api-v1"
 ])

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import net.fabricmc.api.ClientModInitializer;
+
+import net.legacyfabric.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.legacyfabric.fabric.test.registry.RegistryTest;
+
+public class EntityRendererTest implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		EntityRendererRegistry.INSTANCE.register(RegistryTest.TestCreeperEntity.class,
+				(dispatcher, context) -> new TestCreeperEntityRenderer(dispatcher));
+	}
+}

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+
+import net.minecraft.client.render.entity.EntityRenderDispatcher;
+import net.minecraft.client.render.entity.MobEntityRenderer;
+import net.minecraft.client.render.entity.model.CreeperEntityModel;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+
+import net.legacyfabric.fabric.test.registry.RegistryTest;
+
+public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.TestCreeperEntity> {
+	private static final Identifier TEXTURE = new Identifier("legacy-fabric-api", "textures/entity/creeper/creeper.png");
+
+	public TestCreeperEntityRenderer(EntityRenderDispatcher entityRenderDispatcher) {
+		super(entityRenderDispatcher, new CreeperEntityModel(), 0.5F);
+//		this.addFeature(new CreeperLightningFeatureRenderer(this));
+	}
+
+	protected void scale(RegistryTest.TestCreeperEntity creeperEntity, float f) {
+		float g = creeperEntity.getClientFuseTime(f);
+		float h = 1.0F + MathHelper.sin(g * 100.0F) * g * 0.01F;
+		g = MathHelper.clamp(g, 0.0F, 1.0F);
+		g *= g;
+		g *= g;
+		float i = (1.0F + g * 0.4F) * h;
+		float j = (1.0F + g * 0.1F) / h;
+		GlStateManager.scale(i, j, i);
+	}
+
+	protected int method_5776(RegistryTest.TestCreeperEntity creeperEntity, float f, float g) {
+		float h = creeperEntity.getClientFuseTime(g);
+		if ((int)(h * 10.0F) % 2 == 0) {
+			return 0;
+		} else {
+			int i = (int)(h * 0.2F * 255.0F);
+			i = MathHelper.clamp(i, 0, 255);
+			return i << 24 | 822083583;
+		}
+	}
+
+	protected Identifier getTexture(RegistryTest.TestCreeperEntity creeperEntity) {
+		return TEXTURE;
+	}
+}

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -32,7 +32,7 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.Te
 
 	public TestCreeperEntityRenderer(EntityRenderDispatcher entityRenderDispatcher) {
 		super(entityRenderDispatcher, new CreeperEntityModel(), 0.5F);
-//		this.addFeature(new CreeperLightningFeatureRenderer(this));
+		//		this.addFeature(new CreeperLightningFeatureRenderer(this));
 	}
 
 	protected void scale(RegistryTest.TestCreeperEntity creeperEntity, float f) {
@@ -48,10 +48,11 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.Te
 
 	protected int method_5776(RegistryTest.TestCreeperEntity creeperEntity, float f, float g) {
 		float h = creeperEntity.getClientFuseTime(g);
-		if ((int)(h * 10.0F) % 2 == 0) {
+
+		if ((int) (h * 10.0F) % 2 == 0) {
 			return 0;
 		} else {
-			int i = (int)(h * 0.2F * 255.0F);
+			int i = (int) (h * 0.2F * 255.0F);
 			i = MathHelper.clamp(i, 0, 255);
 			return i << 24 | 822083583;
 		}

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -30,6 +30,7 @@ import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
@@ -47,6 +48,7 @@ import net.minecraft.world.World;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.effect.PotionHelper;
+import net.legacyfabric.fabric.api.entity.EntityHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.resource.ItemModelRegistry;
@@ -61,6 +63,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerBlocks();
 		this.registerBlockEntities();
 		this.registerEffectsAndPotions();
+		this.registerEntities();
 	}
 
 	private void registerItems() {
@@ -109,6 +112,12 @@ public class RegistryTest implements ModInitializer {
 		Potion potion = new Potion(potionIdentifier.toTranslationKey(), new StatusEffectInstance(EFFECT, 3600, 5));
 		RegistryHelper.register(Potion.REGISTRY, potionIdentifier, potion);
 		PotionHelper.registerPotionRecipe(Potions.LEAPING, Items.GLISTERING_MELON, potion);
+	}
+
+	private void registerEntities() {
+		Identifier creeperId = new Identifier("legacy-fabric-api", "test_entity");
+		RegistryHelper.register(RegistryIds.ENTITY_TYPES, creeperId, TestCreeperEntity.class);
+		EntityHelper.registerSpawnEgg(creeperId, 12222, 563933);
 	}
 
 	public static class TestBlockWithEntity extends BlockWithEntity {
@@ -161,6 +170,23 @@ public class RegistryTest implements ModInitializer {
 			} else {
 				return true;
 			}
+		}
+	}
+
+	public static class TestCreeperEntity extends CreeperEntity {
+		public TestCreeperEntity(World world) {
+			super(world);
+		}
+
+		@Override
+		public void tick() {
+			if (this.isAlive()) {
+				if (this.hasStatusEffect(EFFECT)) {
+					this.ignite();
+				}
+			}
+
+			super.tick();
 		}
 	}
 }

--- a/legacyfabric-api/1.10.2/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
+++ b/legacyfabric-api/1.10.2/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
@@ -8,5 +8,6 @@
   "effect.legacy-fabric-api.test_effect": "Test Effect",
   "potion.effect.legacy-fabric-api.test_potion": "Test Potion",
   "splash_potion.effect.legacy-fabric-api.test_potion": "Test Potion (Splash)",
-  "lingering_potion.effect.legacy-fabric-api.test_potion": "Test Potion (Lingering)"
+  "lingering_potion.effect.legacy-fabric-api.test_potion": "Test Potion (Lingering)",
+  "entity.legacy-fabric-api.test_entity.name": "Test Entity"
 }

--- a/legacyfabric-api/1.10.2/src/testmod/resources/fabric.mod.json
+++ b/legacyfabric-api/1.10.2/src/testmod/resources/fabric.mod.json
@@ -18,7 +18,8 @@
       "net.legacyfabric.fabric.test.client.rendering.RenderingEventsTest",
       "net.legacyfabric.fabric.test.network.client.ClientNetworkingTest",
       "net.legacyfabric.fabric.test.lifecycle.client.ClientLifecycleEventsTest",
-      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest"
+      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest",
+      "net.legacyfabric.fabric.test.client.rendering.EntityRendererTest"
     ],
     "main": [
       "net.legacyfabric.fabric.test.registry.RegistryTest",

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import net.fabricmc.api.ClientModInitializer;
+
+import net.legacyfabric.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.legacyfabric.fabric.test.registry.RegistryTest;
+
+public class EntityRendererTest implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		EntityRendererRegistry.INSTANCE.register(RegistryTest.TestCreeperEntity.class,
+				(dispatcher, context) -> new TestCreeperEntityRenderer(dispatcher));
+	}
+}

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+
+import net.minecraft.client.render.entity.EntityRenderDispatcher;
+import net.minecraft.client.render.entity.MobEntityRenderer;
+import net.minecraft.client.render.entity.model.CreeperEntityModel;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+
+import net.legacyfabric.fabric.test.registry.RegistryTest;
+
+public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.TestCreeperEntity> {
+	private static final Identifier TEXTURE = new Identifier("legacy-fabric-api", "textures/entity/creeper/creeper.png");
+
+	public TestCreeperEntityRenderer(EntityRenderDispatcher entityRenderDispatcher) {
+		super(entityRenderDispatcher, new CreeperEntityModel(), 0.5F);
+//		this.addFeature(new CreeperLightningFeatureRenderer(this));
+	}
+
+	protected void scale(RegistryTest.TestCreeperEntity creeperEntity, float f) {
+		float g = creeperEntity.getClientFuseTime(f);
+		float h = 1.0F + MathHelper.sin(g * 100.0F) * g * 0.01F;
+		g = MathHelper.clamp(g, 0.0F, 1.0F);
+		g *= g;
+		g *= g;
+		float i = (1.0F + g * 0.4F) * h;
+		float j = (1.0F + g * 0.1F) / h;
+		GlStateManager.scale(i, j, i);
+	}
+
+	protected int method_5776(RegistryTest.TestCreeperEntity creeperEntity, float f, float g) {
+		float h = creeperEntity.getClientFuseTime(g);
+		if ((int)(h * 10.0F) % 2 == 0) {
+			return 0;
+		} else {
+			int i = (int)(h * 0.2F * 255.0F);
+			i = MathHelper.clamp(i, 0, 255);
+			return i << 24 | 822083583;
+		}
+	}
+
+	protected Identifier getTexture(RegistryTest.TestCreeperEntity creeperEntity) {
+		return TEXTURE;
+	}
+}

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -32,7 +32,7 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.Te
 
 	public TestCreeperEntityRenderer(EntityRenderDispatcher entityRenderDispatcher) {
 		super(entityRenderDispatcher, new CreeperEntityModel(), 0.5F);
-//		this.addFeature(new CreeperLightningFeatureRenderer(this));
+		//		this.addFeature(new CreeperLightningFeatureRenderer(this));
 	}
 
 	protected void scale(RegistryTest.TestCreeperEntity creeperEntity, float f) {
@@ -48,10 +48,11 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.Te
 
 	protected int method_5776(RegistryTest.TestCreeperEntity creeperEntity, float f, float g) {
 		float h = creeperEntity.getClientFuseTime(g);
-		if ((int)(h * 10.0F) % 2 == 0) {
+
+		if ((int) (h * 10.0F) % 2 == 0) {
 			return 0;
 		} else {
-			int i = (int)(h * 0.2F * 255.0F);
+			int i = (int) (h * 0.2F * 255.0F);
 			i = MathHelper.clamp(i, 0, 255);
 			return i << 24 | 822083583;
 		}

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -27,9 +27,11 @@ import net.minecraft.block.BlockWithEntity;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.material.MaterialColor;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
@@ -46,6 +48,7 @@ import net.minecraft.world.World;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.effect.PotionHelper;
+import net.legacyfabric.fabric.api.entity.EntityHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.resource.ItemModelRegistry;
@@ -60,6 +63,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerBlocks();
 		this.registerBlockEntities();
 		this.registerEffectsAndPotions();
+		this.registerEntities();
 	}
 
 	private void registerItems() {
@@ -108,6 +112,12 @@ public class RegistryTest implements ModInitializer {
 		Potion potion = new Potion(potionIdentifier.toTranslationKey(), new StatusEffectInstance(EFFECT, 3600, 5));
 		RegistryHelper.register(Potion.REGISTRY, potionIdentifier, potion);
 		PotionHelper.registerPotionRecipe(Potions.LEAPING, Items.GLISTERING_MELON, potion);
+	}
+
+	private void registerEntities() {
+		Identifier creeperId = new Identifier("legacy-fabric-api", "test_entity");
+		RegistryHelper.register(EntityType.REGISTRY, creeperId, TestCreeperEntity.class);
+		EntityHelper.registerSpawnEgg(creeperId, 12222, 563933);
 	}
 
 	public static class TestBlockWithEntity extends BlockWithEntity {
@@ -160,6 +170,23 @@ public class RegistryTest implements ModInitializer {
 			} else {
 				return true;
 			}
+		}
+	}
+
+	public static class TestCreeperEntity extends CreeperEntity {
+		public TestCreeperEntity(World world) {
+			super(world);
+		}
+
+		@Override
+		public void tick() {
+			if (this.isAlive()) {
+				if (this.hasStatusEffect(EFFECT)) {
+					this.ignite();
+				}
+			}
+
+			super.tick();
 		}
 	}
 }

--- a/legacyfabric-api/1.11.2/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
+++ b/legacyfabric-api/1.11.2/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
@@ -8,5 +8,6 @@
   "effect.legacy-fabric-api.test_effect": "Test Effect",
   "potion.effect.legacy-fabric-api.test_potion": "Test Potion",
   "splash_potion.effect.legacy-fabric-api.test_potion": "Test Potion (Splash)",
-  "lingering_potion.effect.legacy-fabric-api.test_potion": "Test Potion (Lingering)"
+  "lingering_potion.effect.legacy-fabric-api.test_potion": "Test Potion (Lingering)",
+  "entity.legacy-fabric-api.test_entity.name": "Test Entity"
 }

--- a/legacyfabric-api/1.11.2/src/testmod/resources/fabric.mod.json
+++ b/legacyfabric-api/1.11.2/src/testmod/resources/fabric.mod.json
@@ -18,7 +18,8 @@
       "net.legacyfabric.fabric.test.client.rendering.RenderingEventsTest",
       "net.legacyfabric.fabric.test.network.client.ClientNetworkingTest",
       "net.legacyfabric.fabric.test.lifecycle.client.ClientLifecycleEventsTest",
-      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest"
+      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest",
+      "net.legacyfabric.fabric.test.client.rendering.EntityRendererTest"
     ],
     "main": [
       "net.legacyfabric.fabric.test.registry.RegistryTest",

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import net.fabricmc.api.ClientModInitializer;
+
+import net.legacyfabric.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.legacyfabric.fabric.test.registry.RegistryTest;
+
+public class EntityRendererTest implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		EntityRendererRegistry.INSTANCE.register(RegistryTest.TestCreeperEntity.class,
+				(dispatcher, context) -> new TestCreeperEntityRenderer(dispatcher));
+	}
+}

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+
+import net.minecraft.client.render.entity.EntityRenderDispatcher;
+import net.minecraft.client.render.entity.MobEntityRenderer;
+import net.minecraft.client.render.entity.model.CreeperEntityModel;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+
+import net.legacyfabric.fabric.test.registry.RegistryTest;
+
+public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.TestCreeperEntity> {
+	private static final Identifier TEXTURE = new Identifier("legacy-fabric-api", "textures/entity/creeper/creeper.png");
+
+	public TestCreeperEntityRenderer(EntityRenderDispatcher entityRenderDispatcher) {
+		super(entityRenderDispatcher, new CreeperEntityModel(), 0.5F);
+//		this.addFeature(new CreeperLightningFeatureRenderer(this));
+	}
+
+	protected void scale(RegistryTest.TestCreeperEntity creeperEntity, float f) {
+		float g = creeperEntity.getClientFuseTime(f);
+		float h = 1.0F + MathHelper.sin(g * 100.0F) * g * 0.01F;
+		g = MathHelper.clamp(g, 0.0F, 1.0F);
+		g *= g;
+		g *= g;
+		float i = (1.0F + g * 0.4F) * h;
+		float j = (1.0F + g * 0.1F) / h;
+		GlStateManager.scale(i, j, i);
+	}
+
+	protected int method_5776(RegistryTest.TestCreeperEntity creeperEntity, float f, float g) {
+		float h = creeperEntity.getClientFuseTime(g);
+		if ((int)(h * 10.0F) % 2 == 0) {
+			return 0;
+		} else {
+			int i = (int)(h * 0.2F * 255.0F);
+			i = MathHelper.clamp(i, 0, 255);
+			return i << 24 | 822083583;
+		}
+	}
+
+	protected Identifier getTexture(RegistryTest.TestCreeperEntity creeperEntity) {
+		return TEXTURE;
+	}
+}

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -32,7 +32,7 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.Te
 
 	public TestCreeperEntityRenderer(EntityRenderDispatcher entityRenderDispatcher) {
 		super(entityRenderDispatcher, new CreeperEntityModel(), 0.5F);
-//		this.addFeature(new CreeperLightningFeatureRenderer(this));
+		//		this.addFeature(new CreeperLightningFeatureRenderer(this));
 	}
 
 	protected void scale(RegistryTest.TestCreeperEntity creeperEntity, float f) {
@@ -48,10 +48,11 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.Te
 
 	protected int method_5776(RegistryTest.TestCreeperEntity creeperEntity, float f, float g) {
 		float h = creeperEntity.getClientFuseTime(g);
-		if ((int)(h * 10.0F) % 2 == 0) {
+
+		if ((int) (h * 10.0F) % 2 == 0) {
 			return 0;
 		} else {
-			int i = (int)(h * 0.2F * 255.0F);
+			int i = (int) (h * 0.2F * 255.0F);
 			i = MathHelper.clamp(i, 0, 255);
 			return i << 24 | 822083583;
 		}

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -27,9 +27,11 @@ import net.minecraft.block.BlockWithEntity;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.material.MaterialColor;
+import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
@@ -46,6 +48,7 @@ import net.minecraft.world.World;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.effect.PotionHelper;
+import net.legacyfabric.fabric.api.entity.EntityHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.resource.ItemModelRegistry;
@@ -60,6 +63,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerBlocks();
 		this.registerBlockEntities();
 		this.registerEffectsAndPotions();
+		this.registerEntities();
 	}
 
 	private void registerItems() {
@@ -108,6 +112,12 @@ public class RegistryTest implements ModInitializer {
 		Potion potion = new Potion(potionIdentifier.toTranslationKey(), new StatusEffectInstance(EFFECT, 3600, 5));
 		RegistryHelper.register(Potion.REGISTRY, potionIdentifier, potion);
 		PotionHelper.registerPotionRecipe(Potions.LEAPING, Items.GLISTERING_MELON, potion);
+	}
+
+	private void registerEntities() {
+		Identifier creeperId = new Identifier("legacy-fabric-api", "test_entity");
+		RegistryHelper.register(EntityType.REGISTRY, creeperId, TestCreeperEntity.class);
+		EntityHelper.registerSpawnEgg(creeperId, 12222, 563933);
 	}
 
 	public static class TestBlockWithEntity extends BlockWithEntity {
@@ -160,6 +170,23 @@ public class RegistryTest implements ModInitializer {
 			} else {
 				return true;
 			}
+		}
+	}
+
+	public static class TestCreeperEntity extends CreeperEntity {
+		public TestCreeperEntity(World world) {
+			super(world);
+		}
+
+		@Override
+		public void tick() {
+			if (this.isAlive()) {
+				if (this.hasStatusEffect(EFFECT)) {
+					this.ignite();
+				}
+			}
+
+			super.tick();
 		}
 	}
 }

--- a/legacyfabric-api/1.12.2/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
+++ b/legacyfabric-api/1.12.2/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
@@ -8,5 +8,6 @@
   "effect.legacy-fabric-api.test_effect": "Test Effect",
   "potion.effect.legacy-fabric-api.test_potion": "Test Potion",
   "splash_potion.effect.legacy-fabric-api.test_potion": "Test Potion (Splash)",
-  "lingering_potion.effect.legacy-fabric-api.test_potion": "Test Potion (Lingering)"
+  "lingering_potion.effect.legacy-fabric-api.test_potion": "Test Potion (Lingering)",
+  "entity.legacy-fabric-api.test_entity.name": "Test Entity"
 }

--- a/legacyfabric-api/1.12.2/src/testmod/resources/fabric.mod.json
+++ b/legacyfabric-api/1.12.2/src/testmod/resources/fabric.mod.json
@@ -18,7 +18,8 @@
       "net.legacyfabric.fabric.test.client.rendering.RenderingEventsTest",
       "net.legacyfabric.fabric.test.network.client.ClientNetworkingTest",
       "net.legacyfabric.fabric.test.lifecycle.client.ClientLifecycleEventsTest",
-      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest"
+      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest",
+      "net.legacyfabric.fabric.test.client.rendering.EntityRendererTest"
     ],
     "main": [
       "net.legacyfabric.fabric.test.registry.RegistryTest",

--- a/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
+++ b/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import net.fabricmc.api.ClientModInitializer;
+
+import net.legacyfabric.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.legacyfabric.fabric.test.registry.RegistryTest;
+
+public class EntityRendererTest implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		EntityRendererRegistry.INSTANCE.register(RegistryTest.TestCreeperEntity.class,
+				(dispatcher, context) -> {
+					TestCreeperEntityRenderer renderer = new TestCreeperEntityRenderer();
+
+					renderer.setRenderDispatcher(dispatcher);
+
+					return renderer;
+				});
+	}
+}

--- a/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -48,6 +48,7 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer {
 		RegistryTest.TestCreeperEntity creeperEntity = (RegistryTest.TestCreeperEntity) entity;
 		float var3 = creeperEntity.getClientFuseTime(f);
 		float var4 = 1.0F + MathHelper.sin(var3 * 100.0F) * var3 * 0.01F;
+
 		if (var3 < 0.0F) {
 			var3 = 0.0F;
 		}
@@ -66,10 +67,12 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer {
 	protected int method_5776(LivingEntity entity, float f, float g) {
 		RegistryTest.TestCreeperEntity creeperEntity = (RegistryTest.TestCreeperEntity) entity;
 		float var4 = creeperEntity.getClientFuseTime(g);
-		if ((int)(var4 * 10.0F) % 2 == 0) {
+
+		if ((int) (var4 * 10.0F) % 2 == 0) {
 			return 0;
 		} else {
-			int var5 = (int)(var4 * 0.2F * 255.0F);
+			int var5 = (int) (var4 * 0.2F * 255.0F);
+
 			if (var5 < 0) {
 				var5 = 0;
 			}
@@ -87,15 +90,12 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer {
 
 	protected int method_5779(LivingEntity entity, int i, float f) {
 		RegistryTest.TestCreeperEntity creeperEntity = (RegistryTest.TestCreeperEntity) entity;
+
 		if (creeperEntity.method_3074()) {
-			if (creeperEntity.isInvisible()) {
-				GL11.glDepthMask(false);
-			} else {
-				GL11.glDepthMask(true);
-			}
+			GL11.glDepthMask(!creeperEntity.isInvisible());
 
 			if (i == 1) {
-				float var4 = (float)creeperEntity.ticksAlive + f;
+				float var4 = (float) creeperEntity.ticksAlive + f;
 				this.bindTexture(field_6472);
 				GL11.glMatrixMode(5890);
 				GL11.glLoadIdentity();

--- a/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import org.lwjgl.opengl.GL11;
+
+import net.minecraft.client.render.entity.MobEntityRenderer;
+import net.minecraft.client.render.entity.model.CreeperEntityModel;
+import net.minecraft.client.render.entity.model.EntityModel;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+
+import net.legacyfabric.fabric.test.registry.RegistryTest;
+
+public class TestCreeperEntityRenderer extends MobEntityRenderer {
+	private static final Identifier field_6472 = new Identifier("textures/entity/creeper/creeper_armor.png");
+	private static final Identifier TEXTURE = new Identifier("legacy-fabric-api", "textures/entity/creeper/creeper.png");
+	private EntityModel field_2086 = new CreeperEntityModel(2.0F);
+
+	public TestCreeperEntityRenderer() {
+		super(new CreeperEntityModel(), 0.5F);
+	}
+
+	@Override
+	public void render(Entity entity, double x, double y, double z, float yaw, float tickDelta) {
+		super.render((MobEntity) entity, x, y, z, yaw, tickDelta);
+	}
+
+	protected void scale(LivingEntity entity, float f) {
+		RegistryTest.TestCreeperEntity creeperEntity = (RegistryTest.TestCreeperEntity) entity;
+		float var3 = creeperEntity.getClientFuseTime(f);
+		float var4 = 1.0F + MathHelper.sin(var3 * 100.0F) * var3 * 0.01F;
+		if (var3 < 0.0F) {
+			var3 = 0.0F;
+		}
+
+		if (var3 > 1.0F) {
+			var3 = 1.0F;
+		}
+
+		var3 *= var3;
+		var3 *= var3;
+		float var5 = (1.0F + var3 * 0.4F) * var4;
+		float var6 = (1.0F + var3 * 0.1F) / var4;
+		GL11.glScalef(var5, var6, var5);
+	}
+
+	protected int method_5776(LivingEntity entity, float f, float g) {
+		RegistryTest.TestCreeperEntity creeperEntity = (RegistryTest.TestCreeperEntity) entity;
+		float var4 = creeperEntity.getClientFuseTime(g);
+		if ((int)(var4 * 10.0F) % 2 == 0) {
+			return 0;
+		} else {
+			int var5 = (int)(var4 * 0.2F * 255.0F);
+			if (var5 < 0) {
+				var5 = 0;
+			}
+
+			if (var5 > 255) {
+				var5 = 255;
+			}
+
+			short var6 = 255;
+			short var7 = 255;
+			short var8 = 255;
+			return var5 << 24 | var6 << 16 | var7 << 8 | var8;
+		}
+	}
+
+	protected int method_5779(LivingEntity entity, int i, float f) {
+		RegistryTest.TestCreeperEntity creeperEntity = (RegistryTest.TestCreeperEntity) entity;
+		if (creeperEntity.method_3074()) {
+			if (creeperEntity.isInvisible()) {
+				GL11.glDepthMask(false);
+			} else {
+				GL11.glDepthMask(true);
+			}
+
+			if (i == 1) {
+				float var4 = (float)creeperEntity.ticksAlive + f;
+				this.bindTexture(field_6472);
+				GL11.glMatrixMode(5890);
+				GL11.glLoadIdentity();
+				float var5 = var4 * 0.01F;
+				float var6 = var4 * 0.01F;
+				GL11.glTranslatef(var5, var6, 0.0F);
+				this.method_5770(this.field_2086);
+				GL11.glMatrixMode(5888);
+				GL11.glEnable(3042);
+				float var7 = 0.5F;
+				GL11.glColor4f(var7, var7, var7, 1.0F);
+				GL11.glDisable(2896);
+				GL11.glBlendFunc(1, 1);
+				return 1;
+			}
+
+			if (i == 2) {
+				GL11.glMatrixMode(5890);
+				GL11.glLoadIdentity();
+				GL11.glMatrixMode(5888);
+				GL11.glEnable(2896);
+				GL11.glDisable(3042);
+			}
+		}
+
+		return -1;
+	}
+
+	protected int method_5784(LivingEntity creeperEntity, int i, float f) {
+		return -1;
+	}
+
+	@Override
+	protected Identifier getTexture(Entity entity) {
+		return TEXTURE;
+	}
+}

--- a/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -27,6 +27,7 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
@@ -37,6 +38,7 @@ import net.minecraft.world.World;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.effect.PotionHelper;
+import net.legacyfabric.fabric.api.entity.EntityHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
@@ -52,6 +54,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerBlocks();
 		this.registerBlockEntities();
 		this.registerEffectsAndPotions();
+		this.registerEntities();
 	}
 
 	private void registerItems() {
@@ -101,6 +104,12 @@ public class RegistryTest implements ModInitializer {
 		);
 		PotionHelper.registerLevels(EFFECT, "!0 & !1 & !2 & !3 & 1+6");
 		PotionHelper.registerAmplifyingFactor(EFFECT, "5");
+	}
+
+	private void registerEntities() {
+		Identifier creeperId = new Identifier("legacy-fabric-api", "test_entity");
+		RegistryHelper.register(RegistryIds.ENTITY_TYPES, creeperId, TestCreeperEntity.class);
+		EntityHelper.registerSpawnEgg(creeperId, 12222, 563933);
 	}
 
 	public static class TestBlockWithEntity extends BlockWithEntity {
@@ -153,6 +162,23 @@ public class RegistryTest implements ModInitializer {
 			} else {
 				return true;
 			}
+		}
+	}
+
+	public static class TestCreeperEntity extends CreeperEntity {
+		public TestCreeperEntity(World world) {
+			super(world);
+		}
+
+		@Override
+		public void tick() {
+			if (this.isAlive()) {
+				if (this.hasStatusEffect(EFFECT)) {
+					this.ignite();
+				}
+			}
+
+			super.tick();
 		}
 	}
 }

--- a/legacyfabric-api/1.7.10/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
+++ b/legacyfabric-api/1.7.10/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
@@ -6,5 +6,6 @@
   "tile.legacy-fabric-api.conc_block_7368816.name": "Test Block 7368816",
   "tile.legacy-fabric-api.test_block_entity.name": "Test Block with Entity",
   "potion.legacy-fabric-api.test_effect": "Test Effect",
-  "potion.legacy-fabric-api.test_effect.postfix": "Potion of Testing"
+  "potion.legacy-fabric-api.test_effect.postfix": "Potion of Testing",
+  "entity.legacy-fabric-api.test_entity.name": "Test Entity"
 }

--- a/legacyfabric-api/1.7.10/src/testmod/resources/fabric.mod.json
+++ b/legacyfabric-api/1.7.10/src/testmod/resources/fabric.mod.json
@@ -17,7 +17,8 @@
       "net.legacyfabric.fabric.test.client.rendering.RenderingEventsTest",
       "net.legacyfabric.fabric.test.network.client.ClientNetworkingTest",
       "net.legacyfabric.fabric.test.lifecycle.client.ClientLifecycleEventsTest",
-      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest"
+      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest",
+      "net.legacyfabric.fabric.test.client.rendering.EntityRendererTest"
     ],
     "main": [
       "net.legacyfabric.fabric.test.registry.RegistryTest",

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import net.fabricmc.api.ClientModInitializer;
+
+import net.legacyfabric.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.legacyfabric.fabric.test.registry.RegistryTest;
+
+public class EntityRendererTest implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		EntityRendererRegistry.INSTANCE.register(RegistryTest.TestCreeperEntity.class,
+				(dispatcher, context) -> new TestCreeperEntityRenderer(dispatcher));
+	}
+}

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+
+import net.minecraft.client.render.entity.EntityRenderDispatcher;
+import net.minecraft.client.render.entity.MobEntityRenderer;
+import net.minecraft.client.render.entity.model.CreeperEntityModel;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+
+import net.legacyfabric.fabric.test.registry.RegistryTest;
+
+public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.TestCreeperEntity> {
+	private static final Identifier TEXTURE = new Identifier("legacy-fabric-api", "textures/entity/creeper/creeper.png");
+
+	public TestCreeperEntityRenderer(EntityRenderDispatcher entityRenderDispatcher) {
+		super(entityRenderDispatcher, new CreeperEntityModel(), 0.5F);
+//		this.addFeature(new CreeperLightningFeatureRenderer(this));
+	}
+
+	protected void scale(RegistryTest.TestCreeperEntity creeperEntity, float f) {
+		float g = creeperEntity.getClientFuseTime(f);
+		float h = 1.0F + MathHelper.sin(g * 100.0F) * g * 0.01F;
+		g = MathHelper.clamp(g, 0.0F, 1.0F);
+		g *= g;
+		g *= g;
+		float i = (1.0F + g * 0.4F) * h;
+		float j = (1.0F + g * 0.1F) / h;
+		GlStateManager.scale(i, j, i);
+	}
+
+	protected int method_5776(RegistryTest.TestCreeperEntity creeperEntity, float f, float g) {
+		float h = creeperEntity.getClientFuseTime(g);
+		if ((int)(h * 10.0F) % 2 == 0) {
+			return 0;
+		} else {
+			int i = (int)(h * 0.2F * 255.0F);
+			i = MathHelper.clamp(i, 0, 255);
+			return i << 24 | 822083583;
+		}
+	}
+
+	protected Identifier getTexture(RegistryTest.TestCreeperEntity creeperEntity) {
+		return TEXTURE;
+	}
+}

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -32,7 +32,7 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.Te
 
 	public TestCreeperEntityRenderer(EntityRenderDispatcher entityRenderDispatcher) {
 		super(entityRenderDispatcher, new CreeperEntityModel(), 0.5F);
-//		this.addFeature(new CreeperLightningFeatureRenderer(this));
+		//		this.addFeature(new CreeperLightningFeatureRenderer(this));
 	}
 
 	protected void scale(RegistryTest.TestCreeperEntity creeperEntity, float f) {
@@ -48,10 +48,11 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.Te
 
 	protected int method_5776(RegistryTest.TestCreeperEntity creeperEntity, float f, float g) {
 		float h = creeperEntity.getClientFuseTime(g);
-		if ((int)(h * 10.0F) % 2 == 0) {
+
+		if ((int) (h * 10.0F) % 2 == 0) {
 			return 0;
 		} else {
-			int i = (int)(h * 0.2F * 255.0F);
+			int i = (int) (h * 0.2F * 255.0F);
 			i = MathHelper.clamp(i, 0, 255);
 			return i << 24 | 822083583;
 		}

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -29,6 +29,7 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
@@ -41,6 +42,7 @@ import net.minecraft.world.World;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.effect.PotionHelper;
+import net.legacyfabric.fabric.api.entity.EntityHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
@@ -57,6 +59,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerBlocks();
 		this.registerBlockEntities();
 		this.registerEffectsAndPotions();
+		this.registerEntities();
 	}
 
 	private void registerItems() {
@@ -105,6 +108,12 @@ public class RegistryTest implements ModInitializer {
 		);
 		PotionHelper.registerLevels(EFFECT, "!0 & !1 & !2 & !3 & 1+6");
 		PotionHelper.registerAmplifyingFactor(EFFECT, "5");
+	}
+
+	private void registerEntities() {
+		Identifier creeperId = new Identifier("legacy-fabric-api", "test_entity");
+		RegistryHelper.register(RegistryIds.ENTITY_TYPES, creeperId, TestCreeperEntity.class);
+		EntityHelper.registerSpawnEgg(creeperId, 12222, 563933);
 	}
 
 	public static class TestBlockWithEntity extends BlockWithEntity {
@@ -157,6 +166,23 @@ public class RegistryTest implements ModInitializer {
 			} else {
 				return true;
 			}
+		}
+	}
+
+	public static class TestCreeperEntity extends CreeperEntity {
+		public TestCreeperEntity(World world) {
+			super(world);
+		}
+
+		@Override
+		public void tick() {
+			if (this.isAlive()) {
+				if (this.hasStatusEffect(EFFECT)) {
+					this.ignite();
+				}
+			}
+
+			super.tick();
 		}
 	}
 }

--- a/legacyfabric-api/1.8.9/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
+++ b/legacyfabric-api/1.8.9/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
@@ -6,5 +6,6 @@
   "tile.legacy-fabric-api.conc_block_3361970.name": "Test Block 3361970",
   "tile.legacy-fabric-api.test_block_entity.name": "Test Block with Entity",
   "potion.legacy-fabric-api.test_effect": "Test Effect",
-  "potion.legacy-fabric-api.test_effect.postfix": "Potion of Testing"
+  "potion.legacy-fabric-api.test_effect.postfix": "Potion of Testing",
+  "entity.legacy-fabric-api.test_entity.name": "Test Entity"
 }

--- a/legacyfabric-api/1.8.9/src/testmod/resources/fabric.mod.json
+++ b/legacyfabric-api/1.8.9/src/testmod/resources/fabric.mod.json
@@ -18,7 +18,8 @@
       "net.legacyfabric.fabric.test.client.rendering.RenderingEventsTest",
       "net.legacyfabric.fabric.test.network.client.ClientNetworkingTest",
       "net.legacyfabric.fabric.test.lifecycle.client.ClientLifecycleEventsTest",
-      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest"
+      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest",
+      "net.legacyfabric.fabric.test.client.rendering.EntityRendererTest"
     ],
     "main": [
       "net.legacyfabric.fabric.test.registry.RegistryTest",

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import net.fabricmc.api.ClientModInitializer;
+
+public class EntityRendererTest implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+//		EntityRendererRegistry.INSTANCE.register(RegistryTest.TestCreeperEntity.class,
+//				(dispatcher, context) -> new TestCreeperEntityRenderer(dispatcher));
+	}
+}

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
@@ -22,7 +22,7 @@ import net.fabricmc.api.ClientModInitializer;
 public class EntityRendererTest implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
-//		EntityRendererRegistry.INSTANCE.register(RegistryTest.TestCreeperEntity.class,
-//				(dispatcher, context) -> new TestCreeperEntityRenderer(dispatcher));
+		//		EntityRendererRegistry.INSTANCE.register(RegistryTest.TestCreeperEntity.class,
+		//				(dispatcher, context) -> new TestCreeperEntityRenderer(dispatcher));
 	}
 }

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+
+import net.minecraft.client.render.entity.EntityRenderDispatcher;
+import net.minecraft.client.render.entity.MobEntityRenderer;
+import net.minecraft.client.render.entity.model.CreeperEntityModel;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+
+import net.legacyfabric.fabric.test.registry.RegistryTest;
+
+public class TestCreeperEntityRenderer extends MobEntityRenderer {
+	private static final Identifier TEXTURE = new Identifier("legacy-fabric-api", "textures/entity/creeper/creeper.png");
+
+	public TestCreeperEntityRenderer(EntityRenderDispatcher entityRenderDispatcher) {
+		super(entityRenderDispatcher, new CreeperEntityModel(), 0.5F);
+//		this.addFeature(new CreeperLightningFeatureRenderer(this));
+	}
+
+	protected void scale(LivingEntity creeperEntity, float f) {
+		float g = ((RegistryTest.TestCreeperEntity) creeperEntity).getClientFuseTime(f);
+		float h = 1.0F + MathHelper.sin(g * 100.0F) * g * 0.01F;
+		g = MathHelper.clamp(g, 0.0F, 1.0F);
+		g *= g;
+		g *= g;
+		float i = (1.0F + g * 0.4F) * h;
+		float j = (1.0F + g * 0.1F) / h;
+		GlStateManager.scale(i, j, i);
+	}
+
+	protected int method_5776(LivingEntity creeperEntity, float f, float g) {
+		float h = ((RegistryTest.TestCreeperEntity) creeperEntity).getClientFuseTime(g);
+		if ((int)(h * 10.0F) % 2 == 0) {
+			return 0;
+		} else {
+			int i = (int)(h * 0.2F * 255.0F);
+			i = MathHelper.clamp(i, 0, 255);
+			return i << 24 | 822083583;
+		}
+	}
+
+	protected Identifier getTexture(Entity creeperEntity) {
+		return TEXTURE;
+	}
+}

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -34,7 +34,7 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer {
 
 	public TestCreeperEntityRenderer(EntityRenderDispatcher entityRenderDispatcher) {
 		super(entityRenderDispatcher, new CreeperEntityModel(), 0.5F);
-//		this.addFeature(new CreeperLightningFeatureRenderer(this));
+		//		this.addFeature(new CreeperLightningFeatureRenderer(this));
 	}
 
 	protected void scale(LivingEntity creeperEntity, float f) {
@@ -50,10 +50,11 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer {
 
 	protected int method_5776(LivingEntity creeperEntity, float f, float g) {
 		float h = ((RegistryTest.TestCreeperEntity) creeperEntity).getClientFuseTime(g);
-		if ((int)(h * 10.0F) % 2 == 0) {
+
+		if ((int) (h * 10.0F) % 2 == 0) {
 			return 0;
 		} else {
-			int i = (int)(h * 0.2F * 255.0F);
+			int i = (int) (h * 0.2F * 255.0F);
 			i = MathHelper.clamp(i, 0, 255);
 			return i << 24 | 822083583;
 		}

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -28,6 +28,7 @@ import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
@@ -40,6 +41,7 @@ import net.minecraft.world.World;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.effect.PotionHelper;
+import net.legacyfabric.fabric.api.entity.EntityHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
@@ -56,6 +58,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerBlocks();
 		this.registerBlockEntities();
 		this.registerEffectsAndPotions();
+		this.registerEntities();
 	}
 
 	private void registerItems() {
@@ -104,6 +107,12 @@ public class RegistryTest implements ModInitializer {
 		);
 		PotionHelper.registerLevels(EFFECT, "!0 & !1 & !2 & !3 & 1+6");
 		PotionHelper.registerAmplifyingFactor(EFFECT, "5");
+	}
+
+	private void registerEntities() {
+		Identifier creeperId = new Identifier("legacy-fabric-api", "test_entity");
+		RegistryHelper.register(RegistryIds.ENTITY_TYPES, creeperId, TestCreeperEntity.class);
+		EntityHelper.registerSpawnEgg(creeperId, 12222, 563933);
 	}
 
 	public static class TestBlockWithEntity extends BlockWithEntity {
@@ -156,6 +165,23 @@ public class RegistryTest implements ModInitializer {
 			} else {
 				return true;
 			}
+		}
+	}
+
+	public static class TestCreeperEntity extends CreeperEntity {
+		public TestCreeperEntity(World world) {
+			super(world);
+		}
+
+		@Override
+		public void tick() {
+			if (this.isAlive()) {
+				if (this.hasStatusEffect(EFFECT)) {
+					this.ignite();
+				}
+			}
+
+			super.tick();
 		}
 	}
 }

--- a/legacyfabric-api/1.8/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
+++ b/legacyfabric-api/1.8/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
@@ -6,5 +6,6 @@
   "tile.legacy-fabric-api.conc_block_7368816.name": "Test Block 7368816",
   "tile.legacy-fabric-api.test_block_entity.name": "Test Block with Entity",
   "potion.legacy-fabric-api.test_effect": "Test Effect",
-  "potion.legacy-fabric-api.test_effect.postfix": "Potion of Testing"
+  "potion.legacy-fabric-api.test_effect.postfix": "Potion of Testing",
+  "entity.legacy-fabric-api.test_entity.name": "Test Entity"
 }

--- a/legacyfabric-api/1.8/src/testmod/resources/fabric.mod.json
+++ b/legacyfabric-api/1.8/src/testmod/resources/fabric.mod.json
@@ -17,7 +17,8 @@
       "net.legacyfabric.fabric.test.client.rendering.RenderingEventsTest",
       "net.legacyfabric.fabric.test.network.client.ClientNetworkingTest",
       "net.legacyfabric.fabric.test.lifecycle.client.ClientLifecycleEventsTest",
-      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest"
+      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest",
+      "net.legacyfabric.fabric.test.client.rendering.EntityRendererTest"
     ],
     "main": [
       "net.legacyfabric.fabric.test.registry.RegistryTest",

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/EntityRendererTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import net.fabricmc.api.ClientModInitializer;
+
+import net.legacyfabric.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.legacyfabric.fabric.test.registry.RegistryTest;
+
+public class EntityRendererTest implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		EntityRendererRegistry.INSTANCE.register(RegistryTest.TestCreeperEntity.class,
+				(dispatcher, context) -> new TestCreeperEntityRenderer(dispatcher));
+	}
+}

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.test.client.rendering;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+
+import net.minecraft.client.render.entity.EntityRenderDispatcher;
+import net.minecraft.client.render.entity.MobEntityRenderer;
+import net.minecraft.client.render.entity.model.CreeperEntityModel;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
+
+import net.legacyfabric.fabric.test.registry.RegistryTest;
+
+public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.TestCreeperEntity> {
+	private static final Identifier TEXTURE = new Identifier("legacy-fabric-api", "textures/entity/creeper/creeper.png");
+
+	public TestCreeperEntityRenderer(EntityRenderDispatcher entityRenderDispatcher) {
+		super(entityRenderDispatcher, new CreeperEntityModel(), 0.5F);
+//		this.addFeature(new CreeperLightningFeatureRenderer(this));
+	}
+
+	protected void scale(RegistryTest.TestCreeperEntity creeperEntity, float f) {
+		float g = creeperEntity.getClientFuseTime(f);
+		float h = 1.0F + MathHelper.sin(g * 100.0F) * g * 0.01F;
+		g = MathHelper.clamp(g, 0.0F, 1.0F);
+		g *= g;
+		g *= g;
+		float i = (1.0F + g * 0.4F) * h;
+		float j = (1.0F + g * 0.1F) / h;
+		GlStateManager.scale(i, j, i);
+	}
+
+	protected int method_5776(RegistryTest.TestCreeperEntity creeperEntity, float f, float g) {
+		float h = creeperEntity.getClientFuseTime(g);
+		if ((int)(h * 10.0F) % 2 == 0) {
+			return 0;
+		} else {
+			int i = (int)(h * 0.2F * 255.0F);
+			i = MathHelper.clamp(i, 0, 255);
+			return i << 24 | 822083583;
+		}
+	}
+
+	protected Identifier getTexture(RegistryTest.TestCreeperEntity creeperEntity) {
+		return TEXTURE;
+	}
+}

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/client/rendering/TestCreeperEntityRenderer.java
@@ -32,7 +32,7 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.Te
 
 	public TestCreeperEntityRenderer(EntityRenderDispatcher entityRenderDispatcher) {
 		super(entityRenderDispatcher, new CreeperEntityModel(), 0.5F);
-//		this.addFeature(new CreeperLightningFeatureRenderer(this));
+		//		this.addFeature(new CreeperLightningFeatureRenderer(this));
 	}
 
 	protected void scale(RegistryTest.TestCreeperEntity creeperEntity, float f) {
@@ -48,10 +48,11 @@ public class TestCreeperEntityRenderer extends MobEntityRenderer<RegistryTest.Te
 
 	protected int method_5776(RegistryTest.TestCreeperEntity creeperEntity, float f, float g) {
 		float h = creeperEntity.getClientFuseTime(g);
-		if ((int)(h * 10.0F) % 2 == 0) {
+
+		if ((int) (h * 10.0F) % 2 == 0) {
 			return 0;
 		} else {
-			int i = (int)(h * 0.2F * 255.0F);
+			int i = (int) (h * 0.2F * 255.0F);
 			i = MathHelper.clamp(i, 0, 255);
 			return i << 24 | 822083583;
 		}

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -30,6 +30,7 @@ import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
@@ -47,6 +48,7 @@ import net.minecraft.world.World;
 import net.fabricmc.api.ModInitializer;
 
 import net.legacyfabric.fabric.api.effect.PotionHelper;
+import net.legacyfabric.fabric.api.entity.EntityHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
@@ -63,6 +65,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerBlocks();
 		this.registerBlockEntities();
 		this.registerEffectsAndPotions();
+		this.registerEntities();
 	}
 
 	private void registerItems() {
@@ -119,6 +122,12 @@ public class RegistryTest implements ModInitializer {
 		PotionHelper.registerPotionRecipe(Potions.LEAPING, Items.GLISTERING_MELON, potion);
 	}
 
+	private void registerEntities() {
+		Identifier creeperId = new Identifier("legacy-fabric-api", "test_entity");
+		RegistryHelper.register(RegistryIds.ENTITY_TYPES, creeperId, TestCreeperEntity.class);
+		EntityHelper.registerSpawnEgg(creeperId, 12222, 563933);
+	}
+
 	public static class TestBlockWithEntity extends BlockWithEntity {
 		protected TestBlockWithEntity(Material material) {
 			super(material);
@@ -169,6 +178,23 @@ public class RegistryTest implements ModInitializer {
 			} else {
 				return true;
 			}
+		}
+	}
+
+	public static class TestCreeperEntity extends CreeperEntity {
+		public TestCreeperEntity(World world) {
+			super(world);
+		}
+
+		@Override
+		public void tick() {
+			if (this.isAlive()) {
+				if (this.hasStatusEffect(EFFECT)) {
+					this.ignite();
+				}
+			}
+
+			super.tick();
 		}
 	}
 }

--- a/legacyfabric-api/1.9.4/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
+++ b/legacyfabric-api/1.9.4/src/testmod/resources/assets/legacy-fabric-api/lang/en_us.json
@@ -8,5 +8,6 @@
   "effect.legacy-fabric-api.test_effect": "Test Effect",
   "potion.effect.legacy-fabric-api.test_potion": "Test Potion",
   "splash_potion.effect.legacy-fabric-api.test_potion": "Test Potion (Splash)",
-  "lingering_potion.effect.legacy-fabric-api.test_potion": "Test Potion (Lingering)"
+  "lingering_potion.effect.legacy-fabric-api.test_potion": "Test Potion (Lingering)",
+  "entity.legacy-fabric-api.test_entity.name": "Test Entity"
 }

--- a/legacyfabric-api/1.9.4/src/testmod/resources/fabric.mod.json
+++ b/legacyfabric-api/1.9.4/src/testmod/resources/fabric.mod.json
@@ -18,7 +18,8 @@
       "net.legacyfabric.fabric.test.client.rendering.RenderingEventsTest",
       "net.legacyfabric.fabric.test.network.client.ClientNetworkingTest",
       "net.legacyfabric.fabric.test.lifecycle.client.ClientLifecycleEventsTest",
-      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest"
+      "net.legacyfabric.fabric.test.client.keybinding.KeybindingTest",
+      "net.legacyfabric.fabric.test.client.rendering.EntityRendererTest"
     ],
     "main": [
       "net.legacyfabric.fabric.test.registry.RegistryTest",

--- a/legacyfabric-api/common.gradle
+++ b/legacyfabric-api/common.gradle
@@ -17,5 +17,6 @@ moduleDependencies(project, [
 	"legacy-fabric-rendering-api-v1",
 	"legacy-fabric-crash-report-info-v1",
 	"legacy-fabric-command-api-v2",
-	"legacy-fabric-effect-api-v1"
+	"legacy-fabric-effect-api-v1",
+	"legacy-fabric-entity-api-v1"
 ])

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,5 +48,6 @@ loadProject("legacy-fabric-rendering-api-v1")
 loadProject("legacy-fabric-crash-report-info-v1")
 loadProject("legacy-fabric-command-api-v2")
 loadProject("legacy-fabric-effect-api-v1")
+loadProject("legacy-fabric-entity-api-v1")
 
 loadProject("legacyfabric-api")


### PR DESCRIPTION
What does this module do:
- Register vanilla Entity Type registry into Registry sync v2 system.
- [Pre-1.9] Remap spawn egg's entity id.
- [NEW] Add helper function to register spawn eggs.
- [NEW] Ensure compatibility with saves created using previous versions of LFAPI.