### PR TITLE
Registry sync v2 - Biome

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -187,7 +187,7 @@
 			- largely unconstained trailing subpackages
 			-->
 			<property name="format"
-			value="^net\.legacyfabric\.fabric\.(api(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+[a-rt-z])+\.v[1-9][0-9]*|(impl|mixin|test)(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+[a-rt-z])+|api\.(event|util|biomes\.v1|registry|client\.screen|command|container|block|entity|client\.itemgroup|client\.keybinding|tag|tools|client\.model|network|server|client\.render|resource|client\.texture|effect|enchantment))(|\.[a-z]+(\.[a-z0-9]+)*)$"/>
+			value="^net\.legacyfabric\.fabric\.(api(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+[a-rt-z])+\.v[1-9][0-9]*|(impl|mixin|test)(?!\.common\.)(\.client|\.server|)(\.(?!client\.|server\.)[a-z]+[a-rt-z])+|api\.(event|util|biomes\.v1|registry|client\.screen|command|container|block|entity|client\.itemgroup|client\.keybinding|tag|tools|client\.model|network|server|client\.render|resource|client\.texture|effect|enchantment|biome))(|\.[a-z]+(\.[a-z0-9]+)*)$"/>
 		</module>
 
 		<!--<module name="InvalidJavadocPosition"/>-->

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,4 @@ legacy-fabric-resource-loader-v1.version = 2.2.2
 legacy-fabric-effect-api-v1.version = 1.0.0
 legacy-fabric-entity-api-v1.version = 1.0.0
 legacy-fabric-enchantment-api-v1.version = 1.0.0
+legacy-fabric-biome-api-v1.version = 1.0.0

--- a/legacy-fabric-biome-api-v1/1.12.2/build.gradle
+++ b/legacy-fabric-biome-api-v1/1.12.2/build.gradle
@@ -1,0 +1,3 @@
+loom {
+	accessWidenerPath = file("src/main/resources/legacy-fabric-biome-api.accesswidener")
+}

--- a/legacy-fabric-biome-api-v1/1.12.2/gradle.properties
+++ b/legacy-fabric-biome-api-v1/1.12.2/gradle.properties
@@ -1,0 +1,2 @@
+minVersionIncluded=1.9
+maxVersionIncluded=1.12.2

--- a/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
+++ b/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
@@ -1,18 +1,34 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.biome.versioned;
+
+import net.minecraft.util.collection.IdList;
+import net.minecraft.world.biome.Biome;
 
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
-
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
 import net.legacyfabric.fabric.api.registry.v2.registry.registrable.IdsHolder;
 import net.legacyfabric.fabric.api.util.Identifier;
 import net.legacyfabric.fabric.mixin.biome.BiomeAccessor;
-
-import net.minecraft.util.collection.IdList;
-import net.minecraft.world.biome.Biome;
 
 public class EarlyInitializer implements PreLaunchEntrypoint {
 	@Override
@@ -20,8 +36,8 @@ public class EarlyInitializer implements PreLaunchEntrypoint {
 		RegistryInitializedEvent.event(RegistryIds.BIOMES).register(EarlyInitializer::biomeRegistryInit);
 	}
 
-	private static void biomeRegistryInit(Registry<?> holder) {
-		SyncedRegistry<Biome> registry = (SyncedRegistry<Biome>) holder;
+	private static void biomeRegistryInit(FabricRegistry<?> holder) {
+		SyncedFabricRegistry<Biome> registry = (SyncedFabricRegistry<Biome>) holder;
 
 		registry.fabric$getBeforeAddedCallback().register((rawId, id, object) -> {
 			((BiomeAccessor) object).setName(id.toTranslationKey());

--- a/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
+++ b/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
@@ -23,6 +23,10 @@ public class EarlyInitializer implements PreLaunchEntrypoint {
 	private static void biomeRegistryInit(Registry<?> holder) {
 		SyncedRegistry<Biome> registry = (SyncedRegistry<Biome>) holder;
 
+		registry.fabric$getBeforeAddedCallback().register((rawId, id, object) -> {
+			((BiomeAccessor) object).setName(id.toTranslationKey());
+		});
+
 		registry.fabric$getEntryAddedCallback().register((rawId, id, object) -> {
 			if (object.hasParent()) {
 				Biome.biomeList.set(object, registry.fabric$getRawId(

--- a/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
+++ b/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
@@ -1,0 +1,52 @@
+package net.legacyfabric.fabric.impl.biome.versioned;
+
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
+
+import net.legacyfabric.fabric.api.registry.v2.registry.registrable.IdsHolder;
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.mixin.biome.BiomeAccessor;
+
+import net.minecraft.util.collection.IdList;
+import net.minecraft.world.biome.Biome;
+
+public class EarlyInitializer implements PreLaunchEntrypoint {
+	@Override
+	public void onPreLaunch() {
+		RegistryInitializedEvent.event(RegistryIds.BIOMES).register(EarlyInitializer::biomeRegistryInit);
+	}
+
+	private static void biomeRegistryInit(Registry<?> holder) {
+		SyncedRegistry<Biome> registry = (SyncedRegistry<Biome>) holder;
+
+		registry.fabric$getEntryAddedCallback().register((rawId, id, object) -> {
+			if (object.hasParent()) {
+				Biome.biomeList.set(object, registry.fabric$getRawId(
+						new Identifier(((BiomeAccessor) object).getParent())
+				));
+			}
+		});
+
+		registry.fabric$getRegistryRemapCallback().register(changedIdsMap -> {
+			IdList<Biome> list = (IdList<Biome>) Biome.biomeList.fabric$new();
+
+			for (Biome biome : (IdsHolder<Biome>) Biome.biomeList) {
+				if (biome == null) continue;
+
+				int index = Biome.biomeList.fabric$getId(biome);
+
+				if (changedIdsMap.containsKey(index)) {
+					index = changedIdsMap.get(index).getId();
+				}
+
+				list.set(biome, index);
+			}
+
+			BiomeAccessor.setBiomeList(list);
+		});
+	}
+}

--- a/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
+++ b/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
@@ -1,0 +1,18 @@
+package net.legacyfabric.fabric.mixin.biome;
+
+import net.minecraft.util.collection.IdList;
+import net.minecraft.world.biome.Biome;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Biome.class)
+public interface BiomeAccessor {
+	@Accessor
+	String getParent();
+
+	@Accessor
+	static void setBiomeList(IdList<Biome> idList) {
+
+	}
+}

--- a/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
+++ b/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
@@ -1,10 +1,27 @@
-package net.legacyfabric.fabric.mixin.biome;
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import net.minecraft.util.collection.IdList;
-import net.minecraft.world.biome.Biome;
+package net.legacyfabric.fabric.mixin.biome;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.util.collection.IdList;
+import net.minecraft.world.biome.Biome;
 
 @Mixin(Biome.class)
 public interface BiomeAccessor {

--- a/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
+++ b/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
@@ -30,7 +30,6 @@ public interface BiomeAccessor {
 
 	@Accessor
 	static void setBiomeList(IdList<Biome> idList) {
-
 	}
 
 	@Accessor

--- a/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
+++ b/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
@@ -15,4 +15,7 @@ public interface BiomeAccessor {
 	static void setBiomeList(IdList<Biome> idList) {
 
 	}
+
+	@Accessor
+	void setName(String name);
 }

--- a/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeMixin.java
+++ b/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeMixin.java
@@ -1,12 +1,21 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.mixin.biome;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.SimpleRegistry;
-import net.minecraft.world.biome.Biome;
 
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,6 +23,13 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.SimpleRegistry;
+import net.minecraft.world.biome.Biome;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 
 @Mixin(Biome.class)
 public class BiomeMixin {

--- a/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeMixin.java
+++ b/legacy-fabric-biome-api-v1/1.12.2/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeMixin.java
@@ -1,0 +1,28 @@
+package net.legacyfabric.fabric.mixin.biome;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.SimpleRegistry;
+import net.minecraft.world.biome.Biome;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Biome.class)
+public class BiomeMixin {
+	@Shadow
+	@Final
+	public static SimpleRegistry<Identifier, Biome> REGISTRY;
+
+	@Inject(method = "register()V", at = @At("RETURN"))
+	private static void api$registerRegistry(CallbackInfo ci) {
+		RegistryHelper.addRegistry(RegistryIds.BIOMES, REGISTRY);
+	}
+}

--- a/legacy-fabric-biome-api-v1/1.12.2/src/main/resources/fabric.mod.json
+++ b/legacy-fabric-biome-api-v1/1.12.2/src/main/resources/fabric.mod.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "id": "legacy-fabric-biome-api-v1",
+  "name": "Legacy Fabric Biome API (V1)",
+  "version": "${version}",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "icon": "assets/legacy-fabric/icon.png",
+  "contact": {
+    "homepage": "https://legacyfabric.net/",
+    "irc": "irc://irc.esper.net:6667/legacyfabric",
+    "issues": "https://github.com/Legacy-Fabric/fabric/issues",
+    "sources": "https://github.com/Legacy-Fabric/fabric"
+  },
+  "authors": [
+    "Legacy-Fabric"
+  ],
+  "depends": {
+    "fabricloader": ">=0.4.0",
+    "minecraft": "${minecraft_version}"
+  },
+  "description": "Biome utils",
+  "entrypoints": {
+    "preLaunch": [
+      "net.legacyfabric.fabric.impl.biome.versioned.EarlyInitializer"
+    ]
+  },
+  "mixins": [
+    "legacy-fabric-biome-api-v1.mixins.json"
+  ],
+  "accessWidener": "legacy-fabric-biome-api.accesswidener",
+  "custom": {
+    "loom:injected_interfaces": {
+    },
+    "modmenu": {
+      "badges": [ "library" ],
+      "parent": {
+        "id": "legacy-fabric-api",
+        "name": "Legacy Fabric API",
+        "badges": [ "library" ],
+        "description": "Core API module providing key hooks and inter-compatibility features for Minecraft 1.7.10-1.12.2.",
+        "icon": "assets/legacy-fabric/icon.png"
+      }
+    }
+  }
+}

--- a/legacy-fabric-biome-api-v1/1.12.2/src/main/resources/legacy-fabric-biome-api-v1.mixins.json
+++ b/legacy-fabric-biome-api-v1/1.12.2/src/main/resources/legacy-fabric-biome-api-v1.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "net.legacyfabric.fabric.mixin.biome",
+  "compatibilityLevel": "JAVA_8",
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "mixins": [
+    "BiomeAccessor",
+    "BiomeMixin"
+  ],
+  "client": [
+  ]
+}

--- a/legacy-fabric-biome-api-v1/1.12.2/src/main/resources/legacy-fabric-biome-api.accesswidener
+++ b/legacy-fabric-biome-api-v1/1.12.2/src/main/resources/legacy-fabric-biome-api.accesswidener
@@ -1,0 +1,6 @@
+accessWidener	v2	named
+
+transitive-accessible method net/minecraft/world/biome/Biome$Settings setBaseHeightModifier (F)Lnet/minecraft/world/biome/Biome$Settings;
+transitive-accessible method net/minecraft/world/biome/Biome$Settings setVariationModifier (F)Lnet/minecraft/world/biome/Biome$Settings;
+transitive-accessible method net/minecraft/world/biome/Biome$Settings setTemperature (F)Lnet/minecraft/world/biome/Biome$Settings;
+transitive-accessible method net/minecraft/world/biome/Biome$Settings setDownfall (F)Lnet/minecraft/world/biome/Biome$Settings;

--- a/legacy-fabric-biome-api-v1/1.7.10/build.gradle
+++ b/legacy-fabric-biome-api-v1/1.7.10/build.gradle
@@ -1,0 +1,3 @@
+loom {
+	accessWidenerPath = file("src/main/resources/legacy-fabric-biome-api.accesswidener")
+}

--- a/legacy-fabric-biome-api-v1/1.7.10/gradle.properties
+++ b/legacy-fabric-biome-api-v1/1.7.10/gradle.properties
@@ -1,0 +1,2 @@
+minVersionIncluded=1.7
+maxVersionIncluded=1.7.10

--- a/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
+++ b/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
@@ -1,0 +1,38 @@
+package net.legacyfabric.fabric.impl.biome.versioned;
+
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.RegistryEntry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
+
+import net.legacyfabric.fabric.mixin.biome.BiomeAccessor;
+
+import net.minecraft.world.biome.Biome;
+
+public class EarlyInitializer implements PreLaunchEntrypoint {
+	@Override
+	public void onPreLaunch() {
+		RegistryInitializedEvent.event(RegistryIds.BIOMES).register(EarlyInitializer::biomeRegistryInit);
+	}
+
+	private static void biomeRegistryInit(Registry<?> holder) {
+		SyncedRegistry<Biome> registry = (SyncedRegistry<Biome>) holder;
+
+		registry.fabric$getEntryAddedCallback().register((rawId, id, object) -> {
+			object.setName(id.toTranslationKey());
+		});
+
+		registry.fabric$getRegistryRemapCallback().register(changedIdsMap -> {
+			for (RegistryEntry<Biome> entry : changedIdsMap.values()) {
+				Biome biome = entry.getValue();
+
+				if (biome != null) {
+					((BiomeAccessor) biome).setId(entry.getId());
+				}
+			}
+		});
+	}
+}

--- a/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
+++ b/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
@@ -1,16 +1,32 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.biome.versioned;
+
+import net.minecraft.world.biome.Biome;
 
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.RegistryEntry;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
-
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistryEntry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
 import net.legacyfabric.fabric.mixin.biome.BiomeAccessor;
-
-import net.minecraft.world.biome.Biome;
 
 public class EarlyInitializer implements PreLaunchEntrypoint {
 	@Override
@@ -18,15 +34,15 @@ public class EarlyInitializer implements PreLaunchEntrypoint {
 		RegistryInitializedEvent.event(RegistryIds.BIOMES).register(EarlyInitializer::biomeRegistryInit);
 	}
 
-	private static void biomeRegistryInit(Registry<?> holder) {
-		SyncedRegistry<Biome> registry = (SyncedRegistry<Biome>) holder;
+	private static void biomeRegistryInit(FabricRegistry<?> holder) {
+		SyncedFabricRegistry<Biome> registry = (SyncedFabricRegistry<Biome>) holder;
 
 		registry.fabric$getEntryAddedCallback().register((rawId, id, object) -> {
 			object.setName(id.toTranslationKey());
 		});
 
 		registry.fabric$getRegistryRemapCallback().register(changedIdsMap -> {
-			for (RegistryEntry<Biome> entry : changedIdsMap.values()) {
+			for (FabricRegistryEntry<Biome> entry : changedIdsMap.values()) {
 				Biome biome = entry.getValue();
 
 				if (biome != null) {

--- a/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
+++ b/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
@@ -1,0 +1,12 @@
+package net.legacyfabric.fabric.mixin.biome;
+
+import net.minecraft.world.biome.Biome;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Biome.class)
+public interface BiomeAccessor {
+	@Accessor
+	void setId(int id);
+}

--- a/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
+++ b/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
@@ -1,9 +1,26 @@
-package net.legacyfabric.fabric.mixin.biome;
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import net.minecraft.world.biome.Biome;
+package net.legacyfabric.fabric.mixin.biome;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.world.biome.Biome;
 
 @Mixin(Biome.class)
 public interface BiomeAccessor {

--- a/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeMixin.java
+++ b/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeMixin.java
@@ -1,18 +1,23 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.mixin.biome;
 
-import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-
-import net.legacyfabric.fabric.impl.biome.EarlyInitializer;
-import net.legacyfabric.fabric.impl.registry.wrapper.SyncedArrayRegistryWrapper;
-
-import net.minecraft.world.biome.Biome;
-
-import net.minecraft.world.biome.TaigaBiome;
-import net.minecraft.world.biome.class_1742;
+import java.util.Arrays;
 
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -23,7 +28,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Arrays;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.TaigaBiome;
+import net.minecraft.world.biome.class_1742;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.impl.biome.EarlyInitializer;
+import net.legacyfabric.fabric.impl.registry.wrapper.SyncedArrayFabricRegistryWrapper;
 
 @Mixin(Biome.class)
 public class BiomeMixin {
@@ -38,7 +51,7 @@ public class BiomeMixin {
 	@Final
 	public static Biome MEGA_TAIGA;
 	@Unique
-	private static Registry<Biome> REGISTRY;
+	private static FabricRegistry<Biome> REGISTRY;
 
 	@Inject(method = "<clinit>", at = @At("RETURN"))
 	private static void api$registerRegistry(CallbackInfo ci) {
@@ -49,7 +62,7 @@ public class BiomeMixin {
 				.setTempratureAndDownfall(0.25F, 0.8F)
 				.method_6422(new class_1742(MEGA_TAIGA.depth, MEGA_TAIGA.variationModifier));
 
-		REGISTRY = new SyncedArrayRegistryWrapper<>(
+		REGISTRY = new SyncedArrayFabricRegistryWrapper<>(
 				RegistryIds.BIOMES,
 				BIOMES, EarlyInitializer.getVanillaIds(),
 				universal -> universal,

--- a/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeMixin.java
+++ b/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeMixin.java
@@ -1,0 +1,80 @@
+package net.legacyfabric.fabric.mixin.biome;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+
+import net.legacyfabric.fabric.impl.biome.EarlyInitializer;
+import net.legacyfabric.fabric.impl.registry.wrapper.SyncedArrayRegistryWrapper;
+
+import net.minecraft.world.biome.Biome;
+
+import net.minecraft.world.biome.TaigaBiome;
+import net.minecraft.world.biome.class_1742;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Arrays;
+
+@Mixin(Biome.class)
+public class BiomeMixin {
+	@Mutable
+	@Shadow
+	@Final
+	private static Biome[] BIOMES;
+	@Shadow
+	@Final
+	public static Biome MEGA_TAIGA_HILLS;
+	@Shadow
+	@Final
+	public static Biome MEGA_TAIGA;
+	@Unique
+	private static Registry<Biome> REGISTRY;
+
+	@Inject(method = "<clinit>", at = @At("RETURN"))
+	private static void api$registerRegistry(CallbackInfo ci) {
+		BIOMES[MEGA_TAIGA_HILLS.id + 128] = new TaigaBiome(MEGA_TAIGA_HILLS.id + 128, 2)
+				.seedModifier(5858897, true)
+				.setName("Mega Spruce Taiga")
+				.method_3820(5159473)
+				.setTempratureAndDownfall(0.25F, 0.8F)
+				.method_6422(new class_1742(MEGA_TAIGA.depth, MEGA_TAIGA.variationModifier));
+
+		REGISTRY = new SyncedArrayRegistryWrapper<>(
+				RegistryIds.BIOMES,
+				BIOMES, EarlyInitializer.getVanillaIds(),
+				universal -> universal,
+				id -> id,
+				ids -> {
+					Biome[] array = new Biome[ids.fabric$size() + 1];
+					Arrays.fill(array, null);
+
+					for (Biome enchantment : ids) {
+						int id = ids.fabric$getId(enchantment);
+
+						if (id >= array.length - 1) {
+							Biome[] newArray = new Biome[id + 2];
+							Arrays.fill(newArray, null);
+							System.arraycopy(array, 0, newArray, 0, array.length);
+							array = newArray;
+						}
+
+						array[id] = enchantment;
+					}
+
+					BIOMES = array;
+				}
+		);
+
+		RegistryHelper.addRegistry(RegistryIds.BIOMES, REGISTRY);
+	}
+}

--- a/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/biome/BootstrapMixin.java
+++ b/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/biome/BootstrapMixin.java
@@ -1,12 +1,29 @@
-package net.legacyfabric.fabric.mixin.biome;
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import net.minecraft.Bootstrap;
-import net.minecraft.world.biome.Biome;
+package net.legacyfabric.fabric.mixin.biome;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.Bootstrap;
+import net.minecraft.world.biome.Biome;
 
 @Mixin(Bootstrap.class)
 public class BootstrapMixin {

--- a/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/biome/BootstrapMixin.java
+++ b/legacy-fabric-biome-api-v1/1.7.10/src/main/java/net/legacyfabric/fabric/mixin/biome/BootstrapMixin.java
@@ -1,0 +1,21 @@
+package net.legacyfabric.fabric.mixin.biome;
+
+import net.minecraft.Bootstrap;
+import net.minecraft.world.biome.Biome;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Bootstrap.class)
+public class BootstrapMixin {
+	@Inject(method = "initialize", at = @At(value = "INVOKE", target = "Lnet/minecraft/Bootstrap;setupDispenserBehavior()V"))
+	private static void initializeBiomeRegistry(CallbackInfo ci) {
+		try {
+			Class.forName(Biome.class.getName());
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/legacy-fabric-biome-api-v1/1.7.10/src/main/resources/fabric.mod.json
+++ b/legacy-fabric-biome-api-v1/1.7.10/src/main/resources/fabric.mod.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "id": "legacy-fabric-biome-api-v1",
+  "name": "Legacy Fabric Biome API (V1)",
+  "version": "${version}",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "icon": "assets/legacy-fabric/icon.png",
+  "contact": {
+    "homepage": "https://legacyfabric.net/",
+    "irc": "irc://irc.esper.net:6667/legacyfabric",
+    "issues": "https://github.com/Legacy-Fabric/fabric/issues",
+    "sources": "https://github.com/Legacy-Fabric/fabric"
+  },
+  "authors": [
+    "Legacy-Fabric"
+  ],
+  "depends": {
+    "fabricloader": ">=0.4.0",
+    "minecraft": "${minecraft_version}"
+  },
+  "description": "Biome utils",
+  "entrypoints": {
+    "preLaunch": [
+      "net.legacyfabric.fabric.impl.biome.versioned.EarlyInitializer"
+    ]
+  },
+  "mixins": [
+    "legacy-fabric-biome-api-v1.mixins.json"
+  ],
+  "accessWidener": "legacy-fabric-biome-api.accesswidener",
+  "custom": {
+    "loom:injected_interfaces": {
+    },
+    "modmenu": {
+      "badges": [ "library" ],
+      "parent": {
+        "id": "legacy-fabric-api",
+        "name": "Legacy Fabric API",
+        "badges": [ "library" ],
+        "description": "Core API module providing key hooks and inter-compatibility features for Minecraft 1.7.10-1.12.2.",
+        "icon": "assets/legacy-fabric/icon.png"
+      }
+    }
+  }
+}

--- a/legacy-fabric-biome-api-v1/1.7.10/src/main/resources/legacy-fabric-biome-api-v1.mixins.json
+++ b/legacy-fabric-biome-api-v1/1.7.10/src/main/resources/legacy-fabric-biome-api-v1.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "net.legacyfabric.fabric.mixin.biome",
+  "compatibilityLevel": "JAVA_8",
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "mixins": [
+    "BiomeAccessor",
+    "BiomeMixin"
+  ],
+  "client": [
+  ]
+}

--- a/legacy-fabric-biome-api-v1/1.7.10/src/main/resources/legacy-fabric-biome-api-v1.mixins.json
+++ b/legacy-fabric-biome-api-v1/1.7.10/src/main/resources/legacy-fabric-biome-api-v1.mixins.json
@@ -7,7 +7,8 @@
   },
   "mixins": [
     "BiomeAccessor",
-    "BiomeMixin"
+    "BiomeMixin",
+    "BootstrapMixin"
   ],
   "client": [
   ]

--- a/legacy-fabric-biome-api-v1/1.7.10/src/main/resources/legacy-fabric-biome-api.accesswidener
+++ b/legacy-fabric-biome-api-v1/1.7.10/src/main/resources/legacy-fabric-biome-api.accesswidener
@@ -1,0 +1,13 @@
+accessWidener	v2	named
+
+transitive-accessible method net/minecraft/world/biome/Biome setName (Ljava/lang/String;)Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome getMutatedVariant ()Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome seedModifier (IZ)Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome method_3827 (I)Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome setSeedModifier (I)Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome method_3820 (I)Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome setMutated ()Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome method_3839 ()Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome method_6422 (Lnet/minecraft/world/biome/class_1742;)Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome setTempratureAndDownfall (FF)Lnet/minecraft/world/biome/Biome;
+accessible method net/minecraft/world/biome/Biome method_6422 (Lnet/minecraft/world/biome/class_1742;)Lnet/minecraft/world/biome/Biome;

--- a/legacy-fabric-biome-api-v1/1.8.9/build.gradle
+++ b/legacy-fabric-biome-api-v1/1.8.9/build.gradle
@@ -1,0 +1,3 @@
+loom {
+	accessWidenerPath = file("src/main/resources/legacy-fabric-biome-api.accesswidener")
+}

--- a/legacy-fabric-biome-api-v1/1.8.9/gradle.properties
+++ b/legacy-fabric-biome-api-v1/1.8.9/gradle.properties
@@ -1,0 +1,2 @@
+minVersionIncluded=1.8
+maxVersionIncluded=1.8.9

--- a/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
+++ b/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
@@ -1,16 +1,32 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.biome.versioned;
+
+import net.minecraft.world.biome.Biome;
 
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 
 import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
 import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.RegistryEntry;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
-
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistryEntry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
 import net.legacyfabric.fabric.mixin.biome.BiomeAccessor;
-
-import net.minecraft.world.biome.Biome;
 
 public class EarlyInitializer implements PreLaunchEntrypoint {
 	@Override
@@ -18,8 +34,8 @@ public class EarlyInitializer implements PreLaunchEntrypoint {
 		RegistryInitializedEvent.event(RegistryIds.BIOMES).register(EarlyInitializer::biomeRegistryInit);
 	}
 
-	private static void biomeRegistryInit(Registry<?> holder) {
-		SyncedRegistry<Biome> registry = (SyncedRegistry<Biome>) holder;
+	private static void biomeRegistryInit(FabricRegistry<?> holder) {
+		SyncedFabricRegistry<Biome> registry = (SyncedFabricRegistry<Biome>) holder;
 
 		registry.fabric$getEntryAddedCallback().register((rawId, id, object) -> {
 			object.setName(id.toTranslationKey());
@@ -27,7 +43,7 @@ public class EarlyInitializer implements PreLaunchEntrypoint {
 		});
 
 		registry.fabric$getRegistryRemapCallback().register(changedIdsMap -> {
-			for (RegistryEntry<Biome> entry : changedIdsMap.values()) {
+			for (FabricRegistryEntry<Biome> entry : changedIdsMap.values()) {
 				Biome biome = entry.getValue();
 
 				if (biome != null) {

--- a/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
+++ b/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/impl/biome/versioned/EarlyInitializer.java
@@ -1,0 +1,39 @@
+package net.legacyfabric.fabric.impl.biome.versioned;
+
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.event.RegistryInitializedEvent;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.RegistryEntry;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedRegistry;
+
+import net.legacyfabric.fabric.mixin.biome.BiomeAccessor;
+
+import net.minecraft.world.biome.Biome;
+
+public class EarlyInitializer implements PreLaunchEntrypoint {
+	@Override
+	public void onPreLaunch() {
+		RegistryInitializedEvent.event(RegistryIds.BIOMES).register(EarlyInitializer::biomeRegistryInit);
+	}
+
+	private static void biomeRegistryInit(Registry<?> holder) {
+		SyncedRegistry<Biome> registry = (SyncedRegistry<Biome>) holder;
+
+		registry.fabric$getEntryAddedCallback().register((rawId, id, object) -> {
+			object.setName(id.toTranslationKey());
+			Biome.MUTATED_BIOMES.put(object.name, object);
+		});
+
+		registry.fabric$getRegistryRemapCallback().register(changedIdsMap -> {
+			for (RegistryEntry<Biome> entry : changedIdsMap.values()) {
+				Biome biome = entry.getValue();
+
+				if (biome != null) {
+					((BiomeAccessor) biome).setId(entry.getId());
+				}
+			}
+		});
+	}
+}

--- a/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
+++ b/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
@@ -1,0 +1,12 @@
+package net.legacyfabric.fabric.mixin.biome;
+
+import net.minecraft.world.biome.Biome;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Biome.class)
+public interface BiomeAccessor {
+	@Accessor
+	void setId(int id);
+}

--- a/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
+++ b/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeAccessor.java
@@ -1,9 +1,26 @@
-package net.legacyfabric.fabric.mixin.biome;
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import net.minecraft.world.biome.Biome;
+package net.legacyfabric.fabric.mixin.biome;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.world.biome.Biome;
 
 @Mixin(Biome.class)
 public interface BiomeAccessor {

--- a/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeMixin.java
+++ b/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeMixin.java
@@ -1,0 +1,64 @@
+package net.legacyfabric.fabric.mixin.biome;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
+
+import net.legacyfabric.fabric.impl.biome.EarlyInitializer;
+import net.legacyfabric.fabric.impl.registry.wrapper.SyncedArrayRegistryWrapper;
+
+import net.minecraft.world.biome.Biome;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Arrays;
+
+@Mixin(Biome.class)
+public class BiomeMixin {
+	@Mutable
+	@Shadow
+	@Final
+	private static Biome[] BIOMES;
+	@Unique
+	private static Registry<Biome> REGISTRY;
+
+	@Inject(method = "<clinit>", at = @At("RETURN"))
+	private static void api$registerRegistry(CallbackInfo ci) {
+		REGISTRY = new SyncedArrayRegistryWrapper<>(
+				RegistryIds.BIOMES,
+				BIOMES, EarlyInitializer.getVanillaIds(),
+				universal -> universal,
+				id -> id,
+				ids -> {
+					Biome[] array = new Biome[ids.fabric$size() + 1];
+					Arrays.fill(array, null);
+
+					for (Biome enchantment : ids) {
+						int id = ids.fabric$getId(enchantment);
+
+						if (id >= array.length - 1) {
+							Biome[] newArray = new Biome[id + 2];
+							Arrays.fill(newArray, null);
+							System.arraycopy(array, 0, newArray, 0, array.length);
+							array = newArray;
+						}
+
+						array[id] = enchantment;
+					}
+
+					BIOMES = array;
+				}
+		);
+
+		RegistryHelper.addRegistry(RegistryIds.BIOMES, REGISTRY);
+	}
+}

--- a/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeMixin.java
+++ b/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/biome/BiomeMixin.java
@@ -1,15 +1,23 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.mixin.biome;
 
-import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.Registry;
-
-import net.legacyfabric.fabric.impl.biome.EarlyInitializer;
-import net.legacyfabric.fabric.impl.registry.wrapper.SyncedArrayRegistryWrapper;
-
-import net.minecraft.world.biome.Biome;
+import java.util.Arrays;
 
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -20,7 +28,13 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.Arrays;
+import net.minecraft.world.biome.Biome;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.FabricRegistry;
+import net.legacyfabric.fabric.impl.biome.EarlyInitializer;
+import net.legacyfabric.fabric.impl.registry.wrapper.SyncedArrayFabricRegistryWrapper;
 
 @Mixin(Biome.class)
 public class BiomeMixin {
@@ -29,11 +43,11 @@ public class BiomeMixin {
 	@Final
 	private static Biome[] BIOMES;
 	@Unique
-	private static Registry<Biome> REGISTRY;
+	private static FabricRegistry<Biome> REGISTRY;
 
 	@Inject(method = "<clinit>", at = @At("RETURN"))
 	private static void api$registerRegistry(CallbackInfo ci) {
-		REGISTRY = new SyncedArrayRegistryWrapper<>(
+		REGISTRY = new SyncedArrayFabricRegistryWrapper<>(
 				RegistryIds.BIOMES,
 				BIOMES, EarlyInitializer.getVanillaIds(),
 				universal -> universal,

--- a/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/biome/BootstrapMixin.java
+++ b/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/biome/BootstrapMixin.java
@@ -1,0 +1,22 @@
+package net.legacyfabric.fabric.mixin.biome;
+
+import net.minecraft.Bootstrap;
+
+import net.minecraft.world.biome.Biome;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Bootstrap.class)
+public class BootstrapMixin {
+	@Inject(method = "initialize", at = @At(value = "INVOKE", target = "Lnet/minecraft/Bootstrap;setupDispenserBehavior()V"))
+	private static void initializeBiomeRegistry(CallbackInfo ci) {
+		try {
+			Class.forName(Biome.class.getName());
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/biome/BootstrapMixin.java
+++ b/legacy-fabric-biome-api-v1/1.8.9/src/main/java/net/legacyfabric/fabric/mixin/biome/BootstrapMixin.java
@@ -1,13 +1,29 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.mixin.biome;
-
-import net.minecraft.Bootstrap;
-
-import net.minecraft.world.biome.Biome;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import net.minecraft.Bootstrap;
+import net.minecraft.world.biome.Biome;
 
 @Mixin(Bootstrap.class)
 public class BootstrapMixin {

--- a/legacy-fabric-biome-api-v1/1.8.9/src/main/resources/fabric.mod.json
+++ b/legacy-fabric-biome-api-v1/1.8.9/src/main/resources/fabric.mod.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "id": "legacy-fabric-biome-api-v1",
+  "name": "Legacy Fabric Biome API (V1)",
+  "version": "${version}",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "icon": "assets/legacy-fabric/icon.png",
+  "contact": {
+    "homepage": "https://legacyfabric.net/",
+    "irc": "irc://irc.esper.net:6667/legacyfabric",
+    "issues": "https://github.com/Legacy-Fabric/fabric/issues",
+    "sources": "https://github.com/Legacy-Fabric/fabric"
+  },
+  "authors": [
+    "Legacy-Fabric"
+  ],
+  "depends": {
+    "fabricloader": ">=0.4.0",
+    "minecraft": "${minecraft_version}"
+  },
+  "description": "Biome utils",
+  "entrypoints": {
+    "preLaunch": [
+      "net.legacyfabric.fabric.impl.biome.versioned.EarlyInitializer"
+    ]
+  },
+  "mixins": [
+    "legacy-fabric-biome-api-v1.mixins.json"
+  ],
+  "accessWidener": "legacy-fabric-biome-api.accesswidener",
+  "custom": {
+    "loom:injected_interfaces": {
+    },
+    "modmenu": {
+      "badges": [ "library" ],
+      "parent": {
+        "id": "legacy-fabric-api",
+        "name": "Legacy Fabric API",
+        "badges": [ "library" ],
+        "description": "Core API module providing key hooks and inter-compatibility features for Minecraft 1.7.10-1.12.2.",
+        "icon": "assets/legacy-fabric/icon.png"
+      }
+    }
+  }
+}

--- a/legacy-fabric-biome-api-v1/1.8.9/src/main/resources/legacy-fabric-biome-api-v1.mixins.json
+++ b/legacy-fabric-biome-api-v1/1.8.9/src/main/resources/legacy-fabric-biome-api-v1.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "net.legacyfabric.fabric.mixin.biome",
+  "compatibilityLevel": "JAVA_8",
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "mixins": [
+    "BiomeAccessor",
+    "BiomeMixin"
+  ],
+  "client": [
+  ]
+}

--- a/legacy-fabric-biome-api-v1/1.8.9/src/main/resources/legacy-fabric-biome-api-v1.mixins.json
+++ b/legacy-fabric-biome-api-v1/1.8.9/src/main/resources/legacy-fabric-biome-api-v1.mixins.json
@@ -7,7 +7,8 @@
   },
   "mixins": [
     "BiomeAccessor",
-    "BiomeMixin"
+    "BiomeMixin",
+    "BootstrapMixin"
   ],
   "client": [
   ]

--- a/legacy-fabric-biome-api-v1/1.8.9/src/main/resources/legacy-fabric-biome-api.accesswidener
+++ b/legacy-fabric-biome-api-v1/1.8.9/src/main/resources/legacy-fabric-biome-api.accesswidener
@@ -1,0 +1,13 @@
+accessWidener	v2	named
+
+transitive-accessible method net/minecraft/world/biome/Biome setName (Ljava/lang/String;)Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome getMutatedVariant ()Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome getMutatedVariant (I)Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome seedModifier (IZ)Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome method_3827 (I)Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome setSeedModifier (I)Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome method_3820 (I)Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome setMutated ()Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome method_3839 ()Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome setHeight (Lnet/minecraft/world/biome/Biome$Height;)Lnet/minecraft/world/biome/Biome;
+transitive-accessible method net/minecraft/world/biome/Biome setTempratureAndDownfall (FF)Lnet/minecraft/world/biome/Biome;

--- a/legacy-fabric-biome-api-v1/common.gradle
+++ b/legacy-fabric-biome-api-v1/common.gradle
@@ -1,0 +1,6 @@
+moduleDependencies(project, [
+    "legacy-fabric-api-base",
+	"legacy-fabric-networking-api-v1",
+	"legacy-fabric-resource-loader-v1",
+	"legacy-fabric-registry-sync-api-v2"
+])

--- a/legacy-fabric-biome-api-v1/common/gradle.properties
+++ b/legacy-fabric-biome-api-v1/common/gradle.properties
@@ -1,0 +1,2 @@
+minVersionIncluded=1.7
+maxVersionIncluded=1.12.2

--- a/legacy-fabric-biome-api-v1/common/src/main/java/net/legacyfabric/fabric/api/biome/BiomeIds.java
+++ b/legacy-fabric-biome-api-v1/common/src/main/java/net/legacyfabric/fabric/api/biome/BiomeIds.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.legacyfabric.fabric.api.biome;
+
+import net.legacyfabric.fabric.api.util.Identifier;
+import net.legacyfabric.fabric.api.util.SinceMC;
+
+public class BiomeIds {
+	public static final Identifier OCEAN = id("ocean");
+	public static final Identifier PLAINS = id("plains");
+	public static final Identifier DESERT = id("desert");
+	public static final Identifier EXTREME_HILLS = id("extreme_hills");
+	public static final Identifier FOREST = id("forest");
+	public static final Identifier TAIGA = id("taiga");
+	public static final Identifier SWAMPLAND = id("swampland");
+	public static final Identifier RIVER = id("river");
+	public static final Identifier HELL = id("hell");
+	public static final Identifier THE_END = id("sky");
+	public static final Identifier FROZEN_OCEAN = id("frozen_ocean");
+	public static final Identifier FROZEN_RIVER = id("frozen_river");
+	public static final Identifier ICE_PLAINS = id("ice_flats");
+	public static final Identifier ICE_MOUNTAINS = id("ice_mountains");
+	public static final Identifier MUSHROOM_ISLAND = id("mushroom_island");
+	public static final Identifier MUSHROOM_ISLAND_SHORE = id("mushroom_island_shore");
+	public static final Identifier BEACH = id("beaches");
+	public static final Identifier DESERT_HILLS = id("desert_hills");
+	public static final Identifier FOREST_HILLS = id("forest_hills");
+	public static final Identifier TAIGA_HILLS = id("taiga_hills");
+	public static final Identifier EXTREME_HILLS_EDGE = id("smaller_extreme_hills");
+	public static final Identifier JUNGLE = id("jungle");
+	public static final Identifier JUNGLE_HILLS = id("jungle_hills");
+	public static final Identifier JUNGLE_EDGE = id("jungle_edge");
+	public static final Identifier DEEP_OCEAN = id("deep_ocean");
+	public static final Identifier STONE_BEACH = id("stone_beach");
+	public static final Identifier COLD_BEACH = id("cold_beach");
+	public static final Identifier BIRCH_FOREST = id("birch_forest");
+	public static final Identifier BIRCH_FOREST_HILLS = id("birch_forest_hills");
+	public static final Identifier ROOFED_FOREST = id("roofed_forest");
+	public static final Identifier COLD_TAIGA = id("taiga_cold");
+	public static final Identifier COLD_TAIGA_HILLS = id("taiga_cold_hills");
+	public static final Identifier MEGA_TAIGA = id("redwood_taiga");
+	public static final Identifier MEGA_TAIGA_HILLS = id("redwood_taiga_hills");
+	public static final Identifier EXTREME_HILLS_PLUS = id("extreme_hills_with_trees");
+	public static final Identifier SAVANNA = id("savanna");
+	public static final Identifier SAVANNA_PLATEAU = id("savanna_rock");
+	public static final Identifier MESA = id("mesa");
+	public static final Identifier MESA_PLATEAU_F = id("mesa_rock");
+	public static final Identifier MESA_PLATEAU = id("mesa_clear_rock");
+	@SinceMC("1.9")
+	public static final Identifier VOID = id("void");
+
+	public static final Identifier SUNFLOWER_PLAINS = id("mutated_plains");
+	public static final Identifier MUTATED_DESERT = id("mutated_desert");
+	public static final Identifier MUTATED_EXTREME_HILLS = id("mutated_extreme_hills");
+	public static final Identifier FLOWER_FOREST = id("mutated_forest");
+	public static final Identifier MUTATED_TAIGA = id("mutated_taiga");
+	public static final Identifier MUTATED_SWAMPLAND = id("mutated_swampland");
+	public static final Identifier ICE_PLAINS_SPIKES = id("mutated_ice_flats");
+	public static final Identifier MUTATED_JUNGLE = id("mutated_jungle");
+	public static final Identifier MUTATED_JUNGLE_EDGE = id("mutated_jungle_edge");
+	public static final Identifier MUTATED_BIRCH_FOREST = id("mutated_birch_forest");
+	/**
+	 * [1.9-1.10.2]: parent is BIRCH_FOREST.
+	 * Pre-1.9 and 1.11+: parent is BIRCH_FOREST_HILLS.
+	 */
+	public static final Identifier MUTATED_BIRCH_FOREST_HILLS = id("mutated_birch_forest_hills");
+	public static final Identifier MUTATED_ROOFED_FOREST = id("mutated_roofed_forest");
+	public static final Identifier MUTATED_COLD_TAIGA = id("mutated_taiga_cold");
+	public static final Identifier MEGA_SPRUCE_TAIGA = id("mutated_redwood_taiga");
+	/**
+	 * Is the same as MUTATED_MEGA_TAIGA before 1.8.
+	 */
+	public static final Identifier MUTATED_REDWOOD_TAIGA_HILLS = id("mutated_redwood_taiga_hills");
+	public static final Identifier MUTATED_EXTREME_HILLS_PLUS = id("mutated_extreme_hills_with_trees");
+	public static final Identifier MUTATED_SAVANNA = id("mutated_savanna");
+	public static final Identifier MUTATED_SAVANNA_PLATEAU = id("mutated_savanna_rock");
+	public static final Identifier MESA_BRYCE = id("mutated_mesa");
+	public static final Identifier MUTATED_MESA_PLATEAU_F = id("mutated_mesa_rock");
+	public static final Identifier MUTATED_MESA_PLATEAU = id("mutated_mesa_clear_rock");
+
+	private static Identifier id(String path) {
+		return new Identifier(path);
+	}
+}

--- a/legacy-fabric-biome-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/biome/EarlyInitializer.java
+++ b/legacy-fabric-biome-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/biome/EarlyInitializer.java
@@ -1,0 +1,10 @@
+package net.legacyfabric.fabric.impl.biome;
+
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+public class EarlyInitializer implements PreLaunchEntrypoint {
+	@Override
+	public void onPreLaunch() {
+
+	}
+}

--- a/legacy-fabric-biome-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/biome/EarlyInitializer.java
+++ b/legacy-fabric-biome-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/biome/EarlyInitializer.java
@@ -2,9 +2,84 @@ package net.legacyfabric.fabric.impl.biome;
 
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 
+import net.legacyfabric.fabric.api.biome.BiomeIds;
+import net.legacyfabric.fabric.api.util.Identifier;
+
+import java.util.HashMap;
+import java.util.Map;
+
 public class EarlyInitializer implements PreLaunchEntrypoint {
 	@Override
 	public void onPreLaunch() {
 
+	}
+
+	public static Map<Integer, Identifier> getVanillaIds() {
+		Map<Integer, Identifier> map = new HashMap<>();
+
+		map.put(0, BiomeIds.OCEAN);
+		map.put(1, BiomeIds.PLAINS);
+		map.put(2, BiomeIds.DESERT);
+		map.put(3, BiomeIds.EXTREME_HILLS);
+		map.put(4, BiomeIds.FOREST);
+		map.put(5, BiomeIds.TAIGA);
+		map.put(6, BiomeIds.SWAMPLAND);
+		map.put(7, BiomeIds.RIVER);
+		map.put(8, BiomeIds.HELL);
+		map.put(9, BiomeIds.THE_END);
+		map.put(10, BiomeIds.FROZEN_OCEAN);
+		map.put(11, BiomeIds.FROZEN_RIVER);
+		map.put(12, BiomeIds.ICE_PLAINS);
+		map.put(13, BiomeIds.ICE_MOUNTAINS);
+		map.put(14, BiomeIds.MUSHROOM_ISLAND);
+		map.put(15, BiomeIds.MUSHROOM_ISLAND_SHORE);
+		map.put(16, BiomeIds.BEACH);
+		map.put(17, BiomeIds.DESERT_HILLS);
+		map.put(18, BiomeIds.FOREST_HILLS);
+		map.put(19, BiomeIds.TAIGA_HILLS);
+		map.put(20, BiomeIds.EXTREME_HILLS_EDGE);
+		map.put(21, BiomeIds.JUNGLE);
+		map.put(22, BiomeIds.JUNGLE_HILLS);
+		map.put(23, BiomeIds.JUNGLE_EDGE);
+		map.put(24, BiomeIds.DEEP_OCEAN);
+		map.put(25, BiomeIds.STONE_BEACH);
+		map.put(26, BiomeIds.COLD_BEACH);
+		map.put(27, BiomeIds.BIRCH_FOREST);
+		map.put(28, BiomeIds.BIRCH_FOREST_HILLS);
+		map.put(29, BiomeIds.ROOFED_FOREST);
+		map.put(30, BiomeIds.COLD_TAIGA);
+		map.put(31, BiomeIds.COLD_TAIGA_HILLS);
+		map.put(32, BiomeIds.MEGA_TAIGA);
+		map.put(33, BiomeIds.MEGA_TAIGA_HILLS);
+		map.put(34, BiomeIds.EXTREME_HILLS_PLUS);
+		map.put(35, BiomeIds.SAVANNA);
+		map.put(36, BiomeIds.SAVANNA_PLATEAU);
+		map.put(37, BiomeIds.MESA);
+		map.put(38, BiomeIds.MESA_PLATEAU_F);
+		map.put(39, BiomeIds.MESA_PLATEAU);
+
+		map.put(129, BiomeIds.SUNFLOWER_PLAINS);
+		map.put(130, BiomeIds.MUTATED_DESERT);
+		map.put(131, BiomeIds.MUTATED_EXTREME_HILLS);
+		map.put(132, BiomeIds.FLOWER_FOREST);
+		map.put(133, BiomeIds.MUTATED_TAIGA);
+		map.put(134, BiomeIds.MUTATED_SWAMPLAND);
+		map.put(140, BiomeIds.ICE_PLAINS_SPIKES);
+		map.put(149, BiomeIds.MUTATED_JUNGLE);
+		map.put(151, BiomeIds.MUTATED_JUNGLE_EDGE);
+		map.put(155, BiomeIds.MUTATED_BIRCH_FOREST);
+		map.put(156, BiomeIds.MUTATED_BIRCH_FOREST_HILLS);
+		map.put(157, BiomeIds.MUTATED_ROOFED_FOREST);
+		map.put(158, BiomeIds.MUTATED_COLD_TAIGA);
+		map.put(160, BiomeIds.MEGA_SPRUCE_TAIGA);
+		map.put(161, BiomeIds.MUTATED_REDWOOD_TAIGA_HILLS);
+		map.put(162, BiomeIds.MUTATED_EXTREME_HILLS_PLUS);
+		map.put(163, BiomeIds.MUTATED_SAVANNA);
+		map.put(164, BiomeIds.MUTATED_SAVANNA_PLATEAU);
+		map.put(165, BiomeIds.MESA_BRYCE);
+		map.put(166, BiomeIds.MUTATED_MESA_PLATEAU_F);
+		map.put(167, BiomeIds.MUTATED_MESA_PLATEAU);
+
+		return map;
 	}
 }

--- a/legacy-fabric-biome-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/biome/EarlyInitializer.java
+++ b/legacy-fabric-biome-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/biome/EarlyInitializer.java
@@ -28,7 +28,6 @@ import net.legacyfabric.fabric.api.util.Identifier;
 public class EarlyInitializer implements PreLaunchEntrypoint {
 	@Override
 	public void onPreLaunch() {
-
 	}
 
 	public static Map<Integer, Identifier> getVanillaIds() {

--- a/legacy-fabric-biome-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/biome/EarlyInitializer.java
+++ b/legacy-fabric-biome-api-v1/common/src/main/java/net/legacyfabric/fabric/impl/biome/EarlyInitializer.java
@@ -1,12 +1,29 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.impl.biome;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 
 import net.legacyfabric.fabric.api.biome.BiomeIds;
 import net.legacyfabric.fabric.api.util.Identifier;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class EarlyInitializer implements PreLaunchEntrypoint {
 	@Override

--- a/legacy-fabric-biome-api-v1/common/src/main/resources/fabric.mod.json
+++ b/legacy-fabric-biome-api-v1/common/src/main/resources/fabric.mod.json
@@ -1,0 +1,44 @@
+{
+  "schemaVersion": 1,
+  "id": "legacy-fabric-biome-api-v1-common",
+  "name": "Legacy Fabric Biome API (V1)",
+  "version": "${version}",
+  "environment": "*",
+  "license": "Apache-2.0",
+  "icon": "assets/legacy-fabric/icon.png",
+  "contact": {
+    "homepage": "https://legacyfabric.net/",
+    "irc": "irc://irc.esper.net:6667/legacyfabric",
+    "issues": "https://github.com/Legacy-Fabric/fabric/issues",
+    "sources": "https://github.com/Legacy-Fabric/fabric"
+  },
+  "authors": [
+    "Legacy-Fabric"
+  ],
+  "depends": {
+    "fabricloader": ">=0.4.0",
+    "minecraft": "${minecraft_version}"
+  },
+  "description": "Biome utils",
+  "entrypoints": {
+    "preLaunch": [
+      "net.legacyfabric.fabric.impl.biome.EarlyInitializer"
+    ]
+  },
+  "mixins": [
+  ],
+  "custom": {
+    "loom:injected_interfaces": {
+    },
+    "modmenu": {
+      "badges": [ "library" ],
+      "parent": {
+        "id": "legacy-fabric-api",
+        "name": "Legacy Fabric API",
+        "badges": [ "library" ],
+        "description": "Core API module providing key hooks and inter-compatibility features for Minecraft 1.7.10-1.12.2.",
+        "icon": "assets/legacy-fabric/icon.png"
+      }
+    }
+  }
+}

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
@@ -1,0 +1,19 @@
+package net.legacyfabric.fabric.test.mixin.biome;
+
+import net.minecraft.client.gui.screen.CustomizeWorldScreen;
+import net.minecraft.world.biome.Biome;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(CustomizeWorldScreen.class)
+public class CustomizeWorldScreenMixin {
+	@ModifyArg(method = "initPages",
+			at = @At(value = "INVOKE", ordinal = 4, target = "Lnet/minecraft/client/gui/widget/PagedEntryListWidget$LabelSupplierEntry;<init>(ILjava/lang/String;ZLnet/minecraft/client/gui/widget/SliderWidget$LabelSupplier;FFF)V"),
+			index = 5
+	)
+	private float allowSelectingAllBiomesInSelector(float max) {
+		return Biome.REGISTRY.stream().mapToInt(b -> Biome.REGISTRY.fabric$getRawId(b)).max().orElse((int) max);
+	}
+}

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
@@ -1,11 +1,28 @@
-package net.legacyfabric.fabric.test.mixin.biome;
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import net.minecraft.client.gui.screen.CustomizeWorldScreen;
-import net.minecraft.world.biome.Biome;
+package net.legacyfabric.fabric.test.mixin.biome;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.client.gui.screen.CustomizeWorldScreen;
+import net.minecraft.world.biome.Biome;
 
 @Mixin(CustomizeWorldScreen.class)
 public class CustomizeWorldScreenMixin {

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
@@ -1,0 +1,17 @@
+package net.legacyfabric.fabric.test.mixin.biome;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.CustomizedWorldProperties;
+
+@Mixin(CustomizedWorldProperties.Serializer.class)
+public class CustomizedWorldPropertiesSerializerMixin {
+	@ModifyConstant(method = "deserialize(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/world/gen/CustomizedWorldProperties$Builder;",
+			constant = @Constant(intValue = 38))
+	private int fixBiomeSelector(int max) {
+		return Biome.REGISTRY.stream().mapToInt(b -> Biome.REGISTRY.fabric$getRawId(b)).max().orElse((int) max);
+	}
+}

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.test.mixin.biome;
 
 import org.spongepowered.asm.mixin.Mixin;

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,6 +19,10 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+import net.minecraft.world.biome.Biome;
+
+import net.minecraft.world.biome.PlainsBiome;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -69,6 +73,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerEffectsAndPotions();
 		this.registerEntities();
 		this.registerEnchantments();
+		this.registerBiomes();
 	}
 
 	private void registerItems() {
@@ -128,6 +133,12 @@ public class RegistryTest implements ModInitializer {
 	private void registerEnchantments() {
 		Identifier enchantmentId = new Identifier("legacy-fabric-api", "test_enchantment");
 		RegistryHelper.register(Enchantment.REGISTRY, enchantmentId, new TestEnchantment());
+	}
+
+	private void registerBiomes() {
+		Identifier biomeId = new Identifier("legacy-fabric-api", "test_biome");
+		RegistryHelper.register(Biome.REGISTRY, biomeId, new TestBiome(false,
+				new Biome.Settings("Test Biome").setBaseHeightModifier(0.525F).setVariationModifier(0.95F).setTemperature(0.3F).setDownfall(0.7F)));
 	}
 
 	public static class TestBlockWithEntity extends BlockWithEntity {
@@ -213,6 +224,12 @@ public class RegistryTest implements ModInitializer {
 		@Override
 		public void onDamaged(LivingEntity bearer, Entity entity, int power) {
 			bearer.addStatusEffect(new StatusEffectInstance(EFFECT, 50, 10));
+		}
+	}
+
+	public static class TestBiome extends PlainsBiome {
+		protected TestBiome(boolean bl, Settings settings) {
+			super(bl, settings);
 		}
 	}
 }

--- a/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.10.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,10 +19,6 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import net.minecraft.world.biome.Biome;
-
-import net.minecraft.world.biome.PlainsBiome;
-
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -52,6 +48,8 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.PlainsBiome;
 
 import net.fabricmc.api.ModInitializer;
 

--- a/legacyfabric-api/1.10.2/src/testmod/resources/test-mod.mixins.json
+++ b/legacyfabric-api/1.10.2/src/testmod/resources/test-mod.mixins.json
@@ -6,8 +6,10 @@
     "defaultRequire": 1
   },
   "mixins": [
+    "biome.CustomizedWorldPropertiesSerializerMixin",
     "effect.LivingEntityMixin"
   ],
   "client": [
+    "biome.CustomizeWorldScreenMixin"
   ]
 }

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
@@ -1,0 +1,19 @@
+package net.legacyfabric.fabric.test.mixin.biome;
+
+import net.minecraft.client.gui.screen.CustomizeWorldScreen;
+import net.minecraft.world.biome.Biome;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(CustomizeWorldScreen.class)
+public class CustomizeWorldScreenMixin {
+	@ModifyArg(method = "initPages",
+			at = @At(value = "INVOKE", ordinal = 4, target = "Lnet/minecraft/client/gui/widget/PagedEntryListWidget$LabelSupplierEntry;<init>(ILjava/lang/String;ZLnet/minecraft/client/gui/widget/SliderWidget$LabelSupplier;FFF)V"),
+			index = 5
+	)
+	private float allowSelectingAllBiomesInSelector(float max) {
+		return Biome.REGISTRY.stream().mapToInt(b -> Biome.REGISTRY.fabric$getRawId(b)).max().orElse((int) max);
+	}
+}

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
@@ -1,11 +1,28 @@
-package net.legacyfabric.fabric.test.mixin.biome;
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import net.minecraft.client.gui.screen.CustomizeWorldScreen;
-import net.minecraft.world.biome.Biome;
+package net.legacyfabric.fabric.test.mixin.biome;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.client.gui.screen.CustomizeWorldScreen;
+import net.minecraft.world.biome.Biome;
 
 @Mixin(CustomizeWorldScreen.class)
 public class CustomizeWorldScreenMixin {

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
@@ -1,0 +1,17 @@
+package net.legacyfabric.fabric.test.mixin.biome;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.CustomizedWorldProperties;
+
+@Mixin(CustomizedWorldProperties.Serializer.class)
+public class CustomizedWorldPropertiesSerializerMixin {
+	@ModifyConstant(method = "deserialize(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/world/gen/CustomizedWorldProperties$Builder;",
+			constant = @Constant(intValue = 38))
+	private int fixBiomeSelector(int max) {
+		return Biome.REGISTRY.stream().mapToInt(b -> Biome.REGISTRY.fabric$getRawId(b)).max().orElse((int) max);
+	}
+}

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.test.mixin.biome;
 
 import org.spongepowered.asm.mixin.Mixin;

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,6 +19,10 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+import net.minecraft.world.biome.Biome;
+
+import net.minecraft.world.biome.PlainsBiome;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -69,6 +73,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerEffectsAndPotions();
 		this.registerEntities();
 		this.registerEnchantments();
+		this.registerBiomes();
 	}
 
 	private void registerItems() {
@@ -128,6 +133,12 @@ public class RegistryTest implements ModInitializer {
 	private void registerEnchantments() {
 		Identifier enchantmentId = new Identifier("legacy-fabric-api", "test_enchantment");
 		RegistryHelper.register(Enchantment.REGISTRY, enchantmentId, new TestEnchantment());
+	}
+
+	private void registerBiomes() {
+		Identifier biomeId = new Identifier("legacy-fabric-api", "test_biome");
+		RegistryHelper.register(Biome.REGISTRY, biomeId, new TestBiome(false,
+				new Biome.Settings("Test Biome").setBaseHeightModifier(0.525F).setVariationModifier(0.95F).setTemperature(0.3F).setDownfall(0.7F)));
 	}
 
 	public static class TestBlockWithEntity extends BlockWithEntity {
@@ -213,6 +224,12 @@ public class RegistryTest implements ModInitializer {
 		@Override
 		public void onDamaged(LivingEntity bearer, Entity entity, int power) {
 			bearer.addStatusEffect(new StatusEffectInstance(EFFECT, 50, 10));
+		}
+	}
+
+	public static class TestBiome extends PlainsBiome {
+		protected TestBiome(boolean bl, Settings settings) {
+			super(bl, settings);
 		}
 	}
 }

--- a/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.11.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,10 +19,6 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import net.minecraft.world.biome.Biome;
-
-import net.minecraft.world.biome.PlainsBiome;
-
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -52,6 +48,8 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.PlainsBiome;
 
 import net.fabricmc.api.ModInitializer;
 

--- a/legacyfabric-api/1.11.2/src/testmod/resources/test-mod.mixins.json
+++ b/legacyfabric-api/1.11.2/src/testmod/resources/test-mod.mixins.json
@@ -6,8 +6,10 @@
     "defaultRequire": 1
   },
   "mixins": [
+    "biome.CustomizedWorldPropertiesSerializerMixin",
     "effect.LivingEntityMixin"
   ],
   "client": [
+    "biome.CustomizeWorldScreenMixin"
   ]
 }

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
@@ -1,0 +1,19 @@
+package net.legacyfabric.fabric.test.mixin.biome;
+
+import net.minecraft.client.gui.screen.CustomizeWorldScreen;
+import net.minecraft.world.biome.Biome;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(CustomizeWorldScreen.class)
+public class CustomizeWorldScreenMixin {
+	@ModifyArg(method = "initPages",
+			at = @At(value = "INVOKE", ordinal = 4, target = "Lnet/minecraft/client/gui/widget/PagedEntryListWidget$LabelSupplierEntry;<init>(ILjava/lang/String;ZLnet/minecraft/client/gui/widget/SliderWidget$LabelSupplier;FFF)V"),
+			index = 5
+	)
+	private float allowSelectingAllBiomesInSelector(float max) {
+		return Biome.REGISTRY.stream().mapToInt(b -> Biome.REGISTRY.fabric$getRawId(b)).max().orElse((int) max);
+	}
+}

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
@@ -1,11 +1,28 @@
-package net.legacyfabric.fabric.test.mixin.biome;
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import net.minecraft.client.gui.screen.CustomizeWorldScreen;
-import net.minecraft.world.biome.Biome;
+package net.legacyfabric.fabric.test.mixin.biome;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.client.gui.screen.CustomizeWorldScreen;
+import net.minecraft.world.biome.Biome;
 
 @Mixin(CustomizeWorldScreen.class)
 public class CustomizeWorldScreenMixin {

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
@@ -1,11 +1,28 @@
-package net.legacyfabric.fabric.test.mixin.biome;
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.gen.CustomizedWorldProperties;
+package net.legacyfabric.fabric.test.mixin.biome;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.CustomizedWorldProperties;
 
 @Mixin(CustomizedWorldProperties.Serializer.class)
 public class CustomizedWorldPropertiesSerializerMixin {

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
@@ -1,0 +1,17 @@
+package net.legacyfabric.fabric.test.mixin.biome;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.CustomizedWorldProperties;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(CustomizedWorldProperties.Serializer.class)
+public class CustomizedWorldPropertiesSerializerMixin {
+	@ModifyConstant(method = "deserialize(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/world/gen/CustomizedWorldProperties$Builder;",
+			constant = @Constant(intValue = 38))
+	private int fixBiomeSelector(int max) {
+		return Biome.REGISTRY.stream().mapToInt(b -> Biome.REGISTRY.fabric$getRawId(b)).max().orElse((int) max);
+	}
+}

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,6 +19,9 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.PlainsBiome;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -69,6 +72,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerEffectsAndPotions();
 		this.registerEntities();
 		this.registerEnchantments();
+		this.registerBiomes();
 	}
 
 	private void registerItems() {
@@ -128,6 +132,12 @@ public class RegistryTest implements ModInitializer {
 	private void registerEnchantments() {
 		Identifier enchantmentId = new Identifier("legacy-fabric-api", "test_enchantment");
 		RegistryHelper.register(Enchantment.REGISTRY, enchantmentId, new TestEnchantment());
+	}
+
+	private void registerBiomes() {
+		Identifier biomeId = new Identifier("legacy-fabric-api", "test_biome");
+		RegistryHelper.register(Biome.REGISTRY, biomeId, new TestBiome(false,
+				new Biome.Settings("Test Biome").setBaseHeightModifier(0.525F).setVariationModifier(0.95F).setTemperature(0.3F).setDownfall(0.7F)));
 	}
 
 	public static class TestBlockWithEntity extends BlockWithEntity {
@@ -213,6 +223,12 @@ public class RegistryTest implements ModInitializer {
 		@Override
 		public void onDamaged(LivingEntity bearer, Entity entity, int power) {
 			bearer.addStatusEffect(new StatusEffectInstance(EFFECT, 50, 10));
+		}
+	}
+
+	public static class TestBiome extends PlainsBiome {
+		protected TestBiome(boolean bl, Settings settings) {
+			super(bl, settings);
 		}
 	}
 }

--- a/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.12.2/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,9 +19,6 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.PlainsBiome;
-
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -51,6 +48,8 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.PlainsBiome;
 
 import net.fabricmc.api.ModInitializer;
 

--- a/legacyfabric-api/1.12.2/src/testmod/resources/test-mod.mixins.json
+++ b/legacyfabric-api/1.12.2/src/testmod/resources/test-mod.mixins.json
@@ -6,8 +6,10 @@
     "defaultRequire": 1
   },
   "mixins": [
+    "biome.CustomizedWorldPropertiesSerializerMixin",
     "effect.LivingEntityMixin"
   ],
   "client": [
+    "biome.CustomizeWorldScreenMixin"
   ]
 }

--- a/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,6 +19,8 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+import net.minecraft.world.biome.PlainsBiome;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -60,6 +62,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerEffectsAndPotions();
 		this.registerEntities();
 		this.registerEnchantments();
+		this.registerBiomes();
 	}
 
 	private void registerItems() {
@@ -126,6 +129,14 @@ public class RegistryTest implements ModInitializer {
 				RegistryHelper.<T>register(registry, enchantmentId, id -> (T) new TestEnchantment(id));
 			}
 		});
+	}
+
+	private void registerBiomes() {
+		Identifier biomeId = new Identifier("legacy-fabric-api", "test_biome");
+		RegistryHelper.register(RegistryIds.BIOMES, biomeId,
+				id -> new TestBiome(id)
+						.setSeedModifier(4446496)
+						.setTempratureAndDownfall(0.3F, 0.7F));
 	}
 
 	public static class TestBlockWithEntity extends BlockWithEntity {
@@ -211,6 +222,12 @@ public class RegistryTest implements ModInitializer {
 		@Override
 		public void onDamaged(LivingEntity bearer, Entity entity, int power) {
 			bearer.addStatusEffect(new StatusEffectInstance(EFFECT.id, 50, 10));
+		}
+	}
+
+	public static class TestBiome extends PlainsBiome {
+		protected TestBiome(int id) {
+			super(id);
 		}
 	}
 }

--- a/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.7.10/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,8 +19,6 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import net.minecraft.world.biome.PlainsBiome;
-
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -40,6 +38,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.itemgroup.ItemGroup;
 import net.minecraft.text.LiteralText;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.PlainsBiome;
 
 import net.fabricmc.api.ModInitializer;
 

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
@@ -1,9 +1,21 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.test.mixin.biome;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,6 +23,10 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 import net.minecraft.client.gui.screen.CustomizeWorldScreen;
 import net.minecraft.world.biome.Biome;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
 
 @Mixin(CustomizeWorldScreen.class)
 public class CustomizeWorldScreenMixin {

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
@@ -1,0 +1,26 @@
+package net.legacyfabric.fabric.test.mixin.biome;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.client.gui.screen.CustomizeWorldScreen;
+import net.minecraft.world.biome.Biome;
+
+@Mixin(CustomizeWorldScreen.class)
+public class CustomizeWorldScreenMixin {
+	@ModifyArg(method = "initPages",
+			at = @At(value = "INVOKE", ordinal = 4, target = "Lnet/minecraft/client/gui/widget/PagedEntryListWidget$LabelSupplierEntry;<init>(ILjava/lang/String;ZLnet/minecraft/client/gui/widget/SliderWidget$LabelSupplier;FFF)V"),
+			index = 5
+	)
+	private float allowSelectingAllBiomesInSelector(float max) {
+		System.out.println(Biome.getBiomes().length);
+		SyncedFabricRegistry<Biome> registry = (SyncedFabricRegistry<Biome>) (Object) RegistryHelper.getRegistry(RegistryIds.BIOMES);
+		return registry.stream().mapToInt(b -> registry.fabric$getRawId(b)).max().orElse((int) max) - 1;
+	}
+}

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
@@ -1,0 +1,23 @@
+package net.legacyfabric.fabric.test.mixin.biome;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.CustomizedWorldProperties;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(CustomizedWorldProperties.Serializer.class)
+public class CustomizedWorldPropertiesSerializerMixin {
+	@ModifyConstant(method = "deserialize(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/world/gen/CustomizedWorldProperties$Builder;",
+			constant = @Constant(intValue = 38))
+	private int fixBiomeSelector(int max) {
+		SyncedFabricRegistry<Biome> registry = (SyncedFabricRegistry<Biome>) (Object) RegistryHelper.getRegistry(RegistryIds.BIOMES);
+		return registry.stream().mapToInt(b -> registry.fabric$getRawId(b)).max().orElse(max) - 1;
+	}
+}

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
@@ -1,16 +1,32 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.test.mixin.biome;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
-
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.gen.CustomizedWorldProperties;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.CustomizedWorldProperties;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
 
 @Mixin(CustomizedWorldProperties.Serializer.class)
 public class CustomizedWorldPropertiesSerializerMixin {

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,6 +19,10 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.MutatedBiome;
+import net.minecraft.world.biome.PlainsBiome;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -65,6 +69,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerEffectsAndPotions();
 		this.registerEntities();
 		this.registerEnchantments();
+		this.registerBiomes();
 	}
 
 	private void registerItems() {
@@ -130,6 +135,15 @@ public class RegistryTest implements ModInitializer {
 				RegistryHelper.<T>register(registry, enchantmentId, id -> (T) new TestEnchantment(id, enchantmentId));
 			}
 		});
+	}
+
+	private void registerBiomes() {
+		Identifier biomeId = new Identifier("legacy-fabric-api", "test_biome");
+		RegistryHelper.register(RegistryIds.BIOMES, biomeId,
+				id -> new TestBiome(id)
+						.setSeedModifier(4446496)
+						.setHeight(new Biome.Height(0.525F, 0.95F))
+						.setTempratureAndDownfall(0.3F, 0.7F));
 	}
 
 	public static class TestBlockWithEntity extends BlockWithEntity {
@@ -215,6 +229,17 @@ public class RegistryTest implements ModInitializer {
 		@Override
 		public void onDamaged(LivingEntity bearer, Entity entity, int power) {
 			bearer.addStatusEffect(new StatusEffectInstance(EFFECT.id, 50, 10));
+		}
+	}
+
+	public static class TestBiome extends PlainsBiome {
+		protected TestBiome(int id) {
+			super(id);
+		}
+
+		@Override
+		public Biome getMutatedVariant(int id) {
+			return new MutatedBiome(id, this);
 		}
 	}
 }

--- a/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.8.9/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,10 +19,6 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.MutatedBiome;
-import net.minecraft.world.biome.PlainsBiome;
-
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -46,6 +42,9 @@ import net.minecraft.text.LiteralText;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.MutatedBiome;
+import net.minecraft.world.biome.PlainsBiome;
 
 import net.fabricmc.api.ModInitializer;
 

--- a/legacyfabric-api/1.8.9/src/testmod/resources/test-mod.mixins.json
+++ b/legacyfabric-api/1.8.9/src/testmod/resources/test-mod.mixins.json
@@ -6,8 +6,10 @@
     "defaultRequire": 1
   },
   "mixins": [
+    "biome.CustomizedWorldPropertiesSerializerMixin",
     "effect.LivingEntityMixin"
   ],
   "client": [
+    "biome.CustomizeWorldScreenMixin"
   ]
 }

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.test.mixin.biome;
 
 import org.spongepowered.asm.mixin.Mixin;

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
@@ -1,0 +1,25 @@
+package net.legacyfabric.fabric.test.mixin.biome;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.client.gui.screen.CustomizeWorldScreen;
+import net.minecraft.world.biome.Biome;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
+
+@Mixin(CustomizeWorldScreen.class)
+public class CustomizeWorldScreenMixin {
+	@ModifyArg(method = "initPages",
+			at = @At(value = "INVOKE", ordinal = 4, target = "Lnet/minecraft/class_2307;<init>(ILjava/lang/String;ZLnet/minecraft/class_2296;FFF)V"),
+			index = 5
+	)
+	private float allowSelectingAllBiomesInSelector(float max) {
+		System.out.println(Biome.getBiomes().length);
+		SyncedFabricRegistry<Biome> registry = (SyncedFabricRegistry<Biome>) (Object) RegistryHelper.getRegistry(RegistryIds.BIOMES);
+		return registry.stream().mapToInt(b -> registry.fabric$getRawId(b)).max().orElse((int) max) - 1;
+	}
+}

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
@@ -1,0 +1,22 @@
+package net.legacyfabric.fabric.test.mixin.biome;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
+
+import net.minecraft.class_2255;
+import net.minecraft.world.biome.Biome;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(class_2255.class)
+public class CustomizedWorldPropertiesSerializerMixin {
+	@ModifyConstant(method = "deserialize(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/class_2254;",
+			constant = @Constant(intValue = 38))
+	private int fixBiomeSelector(int max) {
+		SyncedFabricRegistry<Biome> registry = (SyncedFabricRegistry<Biome>) (Object) RegistryHelper.getRegistry(RegistryIds.BIOMES);
+		return registry.stream().mapToInt(b -> registry.fabric$getRawId(b)).max().orElse(max) - 1;
+	}
+}

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
@@ -1,15 +1,32 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.test.mixin.biome;
-
-import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
-import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
-import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
-
-import net.minecraft.class_2255;
-import net.minecraft.world.biome.Biome;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import net.minecraft.class_2255;
+import net.minecraft.world.biome.Biome;
+
+import net.legacyfabric.fabric.api.registry.v2.RegistryHelper;
+import net.legacyfabric.fabric.api.registry.v2.RegistryIds;
+import net.legacyfabric.fabric.api.registry.v2.registry.holder.SyncedFabricRegistry;
 
 @Mixin(class_2255.class)
 public class CustomizedWorldPropertiesSerializerMixin {

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,6 +19,10 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.MutatedBiome;
+import net.minecraft.world.biome.PlainsBiome;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -64,6 +68,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerEffectsAndPotions();
 		this.registerEntities();
 		this.registerEnchantments();
+		this.registerBiomes();
 	}
 
 	private void registerItems() {
@@ -129,6 +134,14 @@ public class RegistryTest implements ModInitializer {
 				RegistryHelper.<T>register(registry, enchantmentId, id -> (T) new TestEnchantment(id, enchantmentId));
 			}
 		});
+	}
+
+	private void registerBiomes() {
+		Identifier biomeId = new Identifier("legacy-fabric-api", "test_biome");
+		RegistryHelper.register(RegistryIds.BIOMES, biomeId,
+				id -> new TestBiome(id)
+						.setSeedModifier(4446496)
+						.setTempratureAndDownfall(0.3F, 0.7F));
 	}
 
 	public static class TestBlockWithEntity extends BlockWithEntity {
@@ -214,6 +227,17 @@ public class RegistryTest implements ModInitializer {
 		@Override
 		public void onDamaged(LivingEntity bearer, Entity entity, int power) {
 			bearer.addStatusEffect(new StatusEffectInstance(EFFECT.id, 50, 10));
+		}
+	}
+
+	public static class TestBiome extends PlainsBiome {
+		protected TestBiome(int id) {
+			super(id);
+		}
+
+		@Override
+		public Biome getMutatedVariant(int id) {
+			return new MutatedBiome(id, this);
 		}
 	}
 }

--- a/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.8/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,10 +19,6 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.MutatedBiome;
-import net.minecraft.world.biome.PlainsBiome;
-
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -45,6 +41,9 @@ import net.minecraft.text.LiteralText;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.MutatedBiome;
+import net.minecraft.world.biome.PlainsBiome;
 
 import net.fabricmc.api.ModInitializer;
 

--- a/legacyfabric-api/1.8/src/testmod/resources/test-mod.mixins.json
+++ b/legacyfabric-api/1.8/src/testmod/resources/test-mod.mixins.json
@@ -6,8 +6,10 @@
     "defaultRequire": 1
   },
   "mixins": [
+    "biome.CustomizedWorldPropertiesSerializerMixin",
     "effect.LivingEntityMixin"
   ],
   "client": [
+    "biome.CustomizeWorldScreenMixin"
   ]
 }

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
@@ -1,0 +1,19 @@
+package net.legacyfabric.fabric.test.mixin.biome;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import net.minecraft.client.gui.screen.CustomizeWorldScreen;
+import net.minecraft.world.biome.Biome;
+
+@Mixin(CustomizeWorldScreen.class)
+public class CustomizeWorldScreenMixin {
+	@ModifyArg(method = "initPages",
+			at = @At(value = "INVOKE", ordinal = 4, target = "Lnet/minecraft/client/gui/widget/PagedEntryListWidget$LabelSupplierEntry;<init>(ILjava/lang/String;ZLnet/minecraft/client/gui/widget/SliderWidget$LabelSupplier;FFF)V"),
+			index = 5
+	)
+	private float allowSelectingAllBiomesInSelector(float max) {
+		return Biome.REGISTRY.stream().mapToInt(b -> Biome.REGISTRY.fabric$getRawId(b)).max().orElse((int) max);
+	}
+}

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizeWorldScreenMixin.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.legacyfabric.fabric.test.mixin.biome;
 
 import org.spongepowered.asm.mixin.Mixin;

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
@@ -1,11 +1,28 @@
-package net.legacyfabric.fabric.test.mixin.biome;
+/*
+ * Copyright (c) 2020 - 2024 Legacy Fabric
+ * Copyright (c) 2016 - 2022 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import net.minecraft.world.biome.Biome;
-import net.minecraft.world.gen.CustomizedWorldProperties;
+package net.legacyfabric.fabric.test.mixin.biome;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.CustomizedWorldProperties;
 
 @Mixin(CustomizedWorldProperties.Serializer.class)
 public class CustomizedWorldPropertiesSerializerMixin {

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/mixin/biome/CustomizedWorldPropertiesSerializerMixin.java
@@ -1,0 +1,17 @@
+package net.legacyfabric.fabric.test.mixin.biome;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.CustomizedWorldProperties;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(CustomizedWorldProperties.Serializer.class)
+public class CustomizedWorldPropertiesSerializerMixin {
+	@ModifyConstant(method = "deserialize(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/world/gen/CustomizedWorldProperties$Builder;",
+			constant = @Constant(intValue = 38))
+	private int fixBiomeSelector(int max) {
+		return Biome.REGISTRY.stream().mapToInt(b -> Biome.REGISTRY.fabric$getRawId(b)).max().orElse((int) max);
+	}
+}

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,10 +19,6 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-import net.minecraft.world.biome.Biome;
-
-import net.minecraft.world.biome.PlainsBiome;
-
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -52,6 +48,8 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.PlainsBiome;
 
 import net.fabricmc.api.ModInitializer;
 

--- a/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
+++ b/legacyfabric-api/1.9.4/src/testmod/java/net/legacyfabric/fabric/test/registry/RegistryTest.java
@@ -19,6 +19,10 @@ package net.legacyfabric.fabric.test.registry;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+import net.minecraft.world.biome.Biome;
+
+import net.minecraft.world.biome.PlainsBiome;
+
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.block.Block;
@@ -71,6 +75,7 @@ public class RegistryTest implements ModInitializer {
 		this.registerEffectsAndPotions();
 		this.registerEntities();
 		this.registerEnchantments();
+		this.registerBiomes();
 	}
 
 	private void registerItems() {
@@ -136,6 +141,12 @@ public class RegistryTest implements ModInitializer {
 	private void registerEnchantments() {
 		Identifier enchantmentId = new Identifier("legacy-fabric-api", "test_enchantment");
 		RegistryHelper.register(Enchantment.REGISTRY, enchantmentId, new TestEnchantment());
+	}
+
+	private void registerBiomes() {
+		Identifier biomeId = new Identifier("legacy-fabric-api", "test_biome");
+		RegistryHelper.register(Biome.REGISTRY, biomeId, new TestBiome(false,
+				new Biome.Settings("Test Biome").setBaseHeightModifier(0.525F).setVariationModifier(0.95F).setTemperature(0.3F).setDownfall(0.7F)));
 	}
 
 	public static class TestBlockWithEntity extends BlockWithEntity {
@@ -221,6 +232,12 @@ public class RegistryTest implements ModInitializer {
 		@Override
 		public void onDamaged(LivingEntity bearer, Entity entity, int power) {
 			bearer.addStatusEffect(new StatusEffectInstance(EFFECT, 50, 10));
+		}
+	}
+
+	public static class TestBiome extends PlainsBiome {
+		protected TestBiome(boolean bl, Settings settings) {
+			super(bl, settings);
 		}
 	}
 }

--- a/legacyfabric-api/1.9.4/src/testmod/resources/test-mod.mixins.json
+++ b/legacyfabric-api/1.9.4/src/testmod/resources/test-mod.mixins.json
@@ -6,8 +6,10 @@
     "defaultRequire": 1
   },
   "mixins": [
+    "biome.CustomizedWorldPropertiesSerializerMixin",
     "effect.LivingEntityMixin"
   ],
   "client": [
+    "biome.CustomizeWorldScreenMixin"
   ]
 }

--- a/legacyfabric-api/common.gradle
+++ b/legacyfabric-api/common.gradle
@@ -19,5 +19,6 @@ moduleDependencies(project, [
 	"legacy-fabric-command-api-v2",
 	"legacy-fabric-effect-api-v1",
 	"legacy-fabric-entity-api-v1",
-	"legacy-fabric-enchantment-api-v1"
+	"legacy-fabric-enchantment-api-v1",
+	"legacy-fabric-biome-api-v1"
 ])

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,5 +50,6 @@ loadProject("legacy-fabric-command-api-v2")
 loadProject("legacy-fabric-effect-api-v1")
 loadProject("legacy-fabric-entity-api-v1")
 loadProject("legacy-fabric-enchantment-api-v1")
+loadProject("legacy-fabric-biome-api-v1")
 
 loadProject("legacyfabric-api")


### PR DESCRIPTION
What does this module do:

- Register vanilla Biome registry into Registry sync v2 system.
- Set biome translation key from identifier when registering it.
- [1.8+] Transitive access wideners for common Biome settings parameters.
- [1.9.4+] Take set Biome parent into account.