### PR TITLE
Fixed a Bug with ItemGroups

### DIFF
--- a/legacy-fabric-item-groups-v1/common/src/main/java/net/legacyfabric/fabric/mixin/item/group/client/MixinItemGroup.java
+++ b/legacy-fabric-item-groups-v1/common/src/main/java/net/legacyfabric/fabric/mixin/item/group/client/MixinItemGroup.java
@@ -37,7 +37,7 @@ public abstract class MixinItemGroup {
 
 	@Inject(method = "isTopRow", cancellable = true, at = @At("HEAD"))
 	private void isTopRow(CallbackInfoReturnable<Boolean> info) {
-		if (ItemGroup.itemGroups[4].getId() == "hotbar") {
+		if (ItemGroup.itemGroups[4].getId().equals("hotbar")) {
 			if (getIndex() > 11) {
 				info.setReturnValue((getIndex() - 12) % (12 - FabricCreativeGuiComponents.COMMON_GROUPS.size()) < 4);
 			}
@@ -46,13 +46,11 @@ public abstract class MixinItemGroup {
 				info.setReturnValue((getIndex() - 12) % (12 - FabricCreativeGuiComponents.COMMON_GROUPS.size()) < 5);
 			}
 		}
-
 	}
 
 	@Inject(method = "getColumn", cancellable = true, at = @At("HEAD"))
 	private void getColumn(CallbackInfoReturnable<Integer> info) {
-
-		if (ItemGroup.itemGroups[4].getId() == "hotbar") {
+		if (ItemGroup.itemGroups[4].getId().equals("hotbar")) {
 			if (getIndex() > 11) {
 				if (isTopRow()) {
 					info.setReturnValue((getIndex() - 12) % (12 - FabricCreativeGuiComponents.COMMON_GROUPS.size()));
@@ -71,6 +69,5 @@ public abstract class MixinItemGroup {
 				}
 			}
 		}
-
 	}
 }


### PR DESCRIPTION
 Fixed a Bug where if you had more than 9 custom Item Groups it would put one on top of the Survival Inventory tab
 
this bug is caused due to 1.12.2 only having 4 tabs on the top row instead of 5 like 1.11.2 and lower. this is because of the 1.12 save hotbar feature which replaces one tab slot.

 Before:
 
<img width="1920" height="1080" alt="2025-08-22_19 46 46" src="https://github.com/user-attachments/assets/3ee28540-d552-4fcd-991d-7d716bb8dd2e" />

After:

<img width="1920" height="1080" alt="2025-08-22_19 49 09" src="https://github.com/user-attachments/assets/b1c5f125-fa37-472e-af5a-8f00a12f499c" />

